### PR TITLE
add cli command to open/show config

### DIFF
--- a/src/AllImagesQuery.cs
+++ b/src/AllImagesQuery.cs
@@ -6,10 +6,10 @@ namespace port;
 internal class AllImagesQuery : IAllImagesQuery
 {
     private readonly IDockerClient _dockerClient;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
     private readonly IGetContainersQuery _getContainersQuery;
 
-    public AllImagesQuery(IDockerClient dockerClient, Config.Config config, IGetContainersQuery getContainersQuery)
+    public AllImagesQuery(IDockerClient dockerClient, port.Config.Config config, IGetContainersQuery getContainersQuery)
     {
         _dockerClient = dockerClient;
         _config = config;
@@ -27,11 +27,11 @@ internal class AllImagesQuery : IAllImagesQuery
         }
     }
 
-    public async Task<List<Image>> QueryByImageConfigAsync(Config.Config.ImageConfig imageConfig) =>
+    public async Task<List<Image>> QueryByImageConfigAsync(port.Config.Config.ImageConfig imageConfig) =>
         await QueryByImageConfigAsync(imageConfig, _config.ImageConfigs);
 
-    private async Task<List<Image>> QueryByImageConfigAsync(Config.Config.ImageConfig imageConfig,
-        IReadOnlyCollection<Config.Config.ImageConfig> imageConfigs)
+    private async Task<List<Image>> QueryByImageConfigAsync(port.Config.Config.ImageConfig imageConfig,
+        IReadOnlyCollection<port.Config.Config.ImageConfig> imageConfigs)
     {
         var images = await GetBaseImagesAsync(imageConfig).ToListAsync();
         images.AddRange(await GetSnapshotImagesAsync(imageConfigs, imageConfig));
@@ -39,7 +39,7 @@ internal class AllImagesQuery : IAllImagesQuery
         return images;
     }
 
-    private static ImageGroup CreateImageGroup(List<Image> images, Config.Config.ImageConfig imageConfig)
+    private static ImageGroup CreateImageGroup(List<Image> images, port.Config.Config.ImageConfig imageConfig)
     {
         var imageGroup = new ImageGroup(imageConfig.Identifier);
         SetParents(images, imageGroup);
@@ -62,8 +62,8 @@ internal class AllImagesQuery : IAllImagesQuery
     }
 
     private async Task<IEnumerable<Image>> GetSnapshotImagesAsync(
-        IReadOnlyCollection<Config.Config.ImageConfig> imageConfigs,
-        Config.Config.ImageConfig imageConfig)
+        IReadOnlyCollection<port.Config.Config.ImageConfig> imageConfigs,
+        port.Config.Config.ImageConfig imageConfig)
     {
         var imagesListResponses = await GetImagesByNameAsync(imageConfig.ImageName);
         return await Task.WhenAll(imagesListResponses
@@ -92,7 +92,7 @@ internal class AllImagesQuery : IAllImagesQuery
             }));
     }
 
-    private async IAsyncEnumerable<Image> GetBaseImagesAsync(Config.Config.ImageConfig imageConfig)
+    private async IAsyncEnumerable<Image> GetBaseImagesAsync(port.Config.Config.ImageConfig imageConfig)
     {
         var parameters = new ImagesListParameters
         {
@@ -142,7 +142,7 @@ internal class AllImagesQuery : IAllImagesQuery
         }
     }
 
-    private async IAsyncEnumerable<Image> GetUntaggedImagesAsync(Config.Config.ImageConfig imageConfig)
+    private async IAsyncEnumerable<Image> GetUntaggedImagesAsync(port.Config.Config.ImageConfig imageConfig)
     {
         var imagesListResponses = await GetImagesByNameAsync(imageConfig.ImageName);
         foreach (var imagesListResponse in imagesListResponses.Where(e => !e.RepoTags.Any()))
@@ -187,7 +187,7 @@ internal class AllImagesQuery : IAllImagesQuery
         return e.RepoTags != null;
     }
 
-    private static bool IsNotBase(IEnumerable<Config.Config.ImageConfig> imageConfigs, ImagesListResponse e)
+    private static bool IsNotBase(IEnumerable<port.Config.Config.ImageConfig> imageConfigs, ImagesListResponse e)
     {
         return !imageConfigs
             .SelectMany(imageConfig => imageConfig.ImageTags.Select(tag => new
@@ -202,7 +202,7 @@ internal class AllImagesQuery : IAllImagesQuery
             });
     }
 
-    private static bool IsSnapshotOfBase(Config.Config.ImageConfig imageConfig, ImagesListResponse e)
+    private static bool IsSnapshotOfBase(port.Config.Config.ImageConfig imageConfig, ImagesListResponse e)
     {
         var imageNameAndTags = imageConfig.ImageTags.Select(tag => new
         {

--- a/src/Commands/Config/ConfigCliCommand.cs
+++ b/src/Commands/Config/ConfigCliCommand.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+using port.Config;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace port.Commands.Config;
+
+internal class ConfigCliCommand : Command<ConfigSettings>
+{
+    public override int Execute(CommandContext context, ConfigSettings settings)
+    {
+        ConfigFactory.GetOrCreateConfig();
+        var path = ConfigFactory.GetConfigFilePath();
+
+        if (!settings.Open)
+        {
+            AnsiConsole.WriteLine(FormatAsLink(path, path));
+            return 0;
+        }
+
+        Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+        return 0;
+    }
+
+    private static string FormatAsLink(string caption, string url) => $"\u001B]8;;{url}\a{caption}\u001B]8;;\a";
+}

--- a/src/Commands/Config/ConfigSettings.cs
+++ b/src/Commands/Config/ConfigSettings.cs
@@ -1,0 +1,9 @@
+using Spectre.Console.Cli;
+
+namespace port.Commands.Config;
+
+internal class ConfigSettings : CommandSettings
+{
+    [CommandOption("-o|--open")]
+    public bool Open { get; set; } = false;
+}

--- a/src/Commands/Export/ExportCliCommand.cs
+++ b/src/Commands/Export/ExportCliCommand.cs
@@ -8,12 +8,12 @@ internal class ExportCliCommand : AsyncCommand<ExportSettings>
 {
     private readonly IImageIdentifierAndTagEvaluator _imageIdentifierAndTagEvaluator;
     private readonly IImageIdentifierPrompt _imageIdentifierPrompt;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
     private readonly IExportImageCommand _exportImageCommand;
     private readonly IGetImageIdQuery _getImageIdQuery;
 
     public ExportCliCommand(IImageIdentifierAndTagEvaluator imageIdentifierAndTagEvaluator,
-        IImageIdentifierPrompt imageIdentifierPrompt, Config.Config config, IExportImageCommand exportImageCommand,
+        IImageIdentifierPrompt imageIdentifierPrompt, port.Config.Config config, IExportImageCommand exportImageCommand,
         IGetImageIdQuery getImageIdQuery)
     {
         _imageIdentifierAndTagEvaluator = imageIdentifierAndTagEvaluator;

--- a/src/Commands/Import/ImportCliCommand.cs
+++ b/src/Commands/Import/ImportCliCommand.cs
@@ -7,11 +7,11 @@ namespace port.Commands.Import;
 internal class ImportCliCommand : AsyncCommand<ImportSettings>
 {
     private readonly IImageIdentifierPrompt _imageIdentifierPrompt;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
     private readonly IImportImageCommand _importImageCommand;
     private readonly IGetImageIdQuery _getImageIdQuery;
 
-    public ImportCliCommand(IImageIdentifierPrompt imageIdentifierPrompt, Config.Config config, IImportImageCommand importImageCommand,
+    public ImportCliCommand(IImageIdentifierPrompt imageIdentifierPrompt, port.Config.Config config, IImportImageCommand importImageCommand,
         IGetImageIdQuery getImageIdQuery)
     {
         _imageIdentifierPrompt = imageIdentifierPrompt;

--- a/src/Commands/Orphan/OrphanCliCommand.cs
+++ b/src/Commands/Orphan/OrphanCliCommand.cs
@@ -7,12 +7,12 @@ internal class OrphanCliCommand : AsyncCommand<OrphanSettings>
 {
     private readonly IImageIdentifierAndTagEvaluator _imageIdentifierAndTagEvaluator;
     private readonly IImageIdentifierPrompt _imageIdentifierPrompt;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
     private readonly IOrphanImageCommand _orphanImageCommand;
     private readonly IGetImageIdQuery _getImageIdQuery;
 
     public OrphanCliCommand(IImageIdentifierAndTagEvaluator imageIdentifierAndTagEvaluator,
-        IImageIdentifierPrompt imageIdentifierPrompt, Config.Config config, IOrphanImageCommand orphanImageCommand,
+        IImageIdentifierPrompt imageIdentifierPrompt, port.Config.Config config, IOrphanImageCommand orphanImageCommand,
         IGetImageIdQuery getImageIdQuery)
     {
         _imageIdentifierAndTagEvaluator = imageIdentifierAndTagEvaluator;

--- a/src/Commands/Prune/PruneCliCommand.cs
+++ b/src/Commands/Prune/PruneCliCommand.cs
@@ -8,13 +8,13 @@ internal class PruneCliCommand : AsyncCommand<PruneSettings>
 {
     private readonly IImageIdentifierAndTagEvaluator _imageIdentifierAndTagEvaluator;
     private readonly IGetImageIdQuery _getImageIdQuery;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
     private readonly IAllImagesQuery _allImagesQuery;
     private readonly IRemoveImagesCliDependentCommand _removeImagesCliDependentCommand;
     private readonly ListCliCommand _listCliCommand;
 
     public PruneCliCommand(IImageIdentifierAndTagEvaluator imageIdentifierAndTagEvaluator,
-        IGetImageIdQuery getImageIdQuery, Config.Config config, IAllImagesQuery allImagesQuery,
+        IGetImageIdQuery getImageIdQuery, port.Config.Config config, IAllImagesQuery allImagesQuery,
         IRemoveImagesCliDependentCommand removeImagesCliDependentCommand, ListCliCommand listCliCommand)
     {
         _imageIdentifierAndTagEvaluator = imageIdentifierAndTagEvaluator;

--- a/src/Commands/Pull/PullCliCommand.cs
+++ b/src/Commands/Pull/PullCliCommand.cs
@@ -5,11 +5,11 @@ namespace port.Commands.Pull;
 public class PullCliCommand : AsyncCommand<PullSettings>
 {
     private readonly IImageIdentifierPrompt _imageIdentifierPrompt;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
     private readonly IImageIdentifierAndTagEvaluator _imageIdentifierAndTagEvaluator;
     private readonly ICreateImageCliChildCommand _createImageCliChildCommand;
 
-    public PullCliCommand(IImageIdentifierPrompt imageIdentifierPrompt, Config.Config config,
+    public PullCliCommand(IImageIdentifierPrompt imageIdentifierPrompt, port.Config.Config config,
         IImageIdentifierAndTagEvaluator imageIdentifierAndTagEvaluator,
         ICreateImageCliChildCommand createImageCliChildCommand)
     {

--- a/src/Commands/Remove/RemoveCliCommand.cs
+++ b/src/Commands/Remove/RemoveCliCommand.cs
@@ -8,13 +8,13 @@ internal class RemoveCliCommand : AsyncCommand<RemoveSettings>
 {
     private readonly IImageIdentifierPrompt _imageIdentifierPrompt;
     private readonly IGetImageIdQuery _getImageIdQuery;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
     private readonly IImageIdentifierAndTagEvaluator _imageIdentifierAndTagEvaluator;
     private readonly IAllImagesQuery _allImagesQuery;
     private readonly IRemoveImagesCliDependentCommand _removeImagesCliDependentCommand;
     private readonly ListCliCommand _listCliCommand;
 
-    public RemoveCliCommand(IImageIdentifierPrompt imageIdentifierPrompt, Config.Config config,
+    public RemoveCliCommand(IImageIdentifierPrompt imageIdentifierPrompt, port.Config.Config config,
         IImageIdentifierAndTagEvaluator imageIdentifierAndTagEvaluator, IGetImageIdQuery getImageIdQuery,
         IAllImagesQuery allImagesQuery, IRemoveImagesCliDependentCommand removeImagesCliDependentCommand,
         ListCliCommand listCliCommand)

--- a/src/Commands/Run/RunCliCommand.cs
+++ b/src/Commands/Run/RunCliCommand.cs
@@ -13,7 +13,7 @@ internal class RunCliCommand : AsyncCommand<RunSettings>
     private readonly ICreateContainerCommand _createContainerCommand;
     private readonly IRunContainerCommand _runContainerCommand;
     private readonly IStopContainerCommand _stopContainerCommand;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
     private readonly IImageIdentifierAndTagEvaluator _imageIdentifierAndTagEvaluator;
     private readonly IStopAndRemoveContainerCommand _stopAndRemoveContainerCommand;
     private readonly ListCliCommand _listCliCommand;
@@ -24,7 +24,7 @@ internal class RunCliCommand : AsyncCommand<RunSettings>
         ICreateImageCliChildCommand createImageCliChildCommand, IDoesImageExistQuery doesImageExistQuery,
         IGetContainersQuery getContainersQuery,
         ICreateContainerCommand createContainerCommand, IRunContainerCommand runContainerCommand,
-        IStopContainerCommand stopContainerCommand, Config.Config config,
+        IStopContainerCommand stopContainerCommand, port.Config.Config config,
         IImageIdentifierAndTagEvaluator imageIdentifierAndTagEvaluator,
         IStopAndRemoveContainerCommand stopAndRemoveContainerCommand, ListCliCommand listCliCommand)
     {

--- a/src/Config/ConfigFactory.cs
+++ b/src/Config/ConfigFactory.cs
@@ -35,7 +35,7 @@ public static class ConfigFactory
         }
     }
 
-    private static string GetConfigFilePath()
+    public static string GetConfigFilePath()
     {
         var userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var configFilePath = Path.Combine(userProfilePath, ConfigFileName);

--- a/src/GetRunningContainersQuery.cs
+++ b/src/GetRunningContainersQuery.cs
@@ -6,9 +6,9 @@ namespace port;
 internal class GetRunningContainersQuery : IGetRunningContainersQuery
 {
     private readonly IDockerClient _dockerClient;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
 
-    public GetRunningContainersQuery(IDockerClient dockerClient, Config.Config config)
+    public GetRunningContainersQuery(IDockerClient dockerClient, port.Config.Config config)
     {
         _dockerClient = dockerClient;
         _config = config;

--- a/src/IAllImagesQuery.cs
+++ b/src/IAllImagesQuery.cs
@@ -3,5 +3,5 @@ namespace port;
 internal interface IAllImagesQuery
 {
     IAsyncEnumerable<ImageGroup> QueryAsync();
-    Task<List<Image>> QueryByImageConfigAsync(Config.Config.ImageConfig imageConfig);
+    Task<List<Image>> QueryByImageConfigAsync(port.Config.Config.ImageConfig imageConfig);
 }

--- a/src/ImageIdentifierAndTagEvaluator.cs
+++ b/src/ImageIdentifierAndTagEvaluator.cs
@@ -2,9 +2,9 @@ namespace port;
 
 internal class ImageIdentifierAndTagEvaluator : IImageIdentifierAndTagEvaluator
 {
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
 
-    public ImageIdentifierAndTagEvaluator(Config.Config config)
+    public ImageIdentifierAndTagEvaluator(port.Config.Config config)
     {
         _config = config;
     }

--- a/src/ImageIdentifierPrompt.cs
+++ b/src/ImageIdentifierPrompt.cs
@@ -5,9 +5,9 @@ namespace port;
 internal class ImageIdentifierPrompt : IImageIdentifierPrompt
 {
     private readonly IAllImagesQuery _allImagesQuery;
-    private readonly Config.Config _config;
+    private readonly port.Config.Config _config;
 
-    public ImageIdentifierPrompt(IAllImagesQuery allImagesQuery, Config.Config config)
+    public ImageIdentifierPrompt(IAllImagesQuery allImagesQuery, port.Config.Config config)
     {
         _allImagesQuery = allImagesQuery;
         _config = config;
@@ -21,7 +21,7 @@ internal class ImageIdentifierPrompt : IImageIdentifierPrompt
             selectionPrompt.AddChoice(imageConfig);
         }
 
-        var selectedImageConfig = (Config.Config.ImageConfig)AnsiConsole.Prompt(selectionPrompt);
+        var selectedImageConfig = (port.Config.Config.ImageConfig)AnsiConsole.Prompt(selectionPrompt);
         return selectedImageConfig.Identifier;
     }
 
@@ -97,7 +97,7 @@ internal class ImageIdentifierPrompt : IImageIdentifierPrompt
                 {
                     Image image => TagTextBuilder.BuildTagText(image, true),
                     ImageGroup imageGroup => $"[white]{imageGroup.Identifier}[/]",
-                    Config.Config.ImageConfig imageConfig => $"[white]{imageConfig.Identifier}[/]",
+                    port.Config.Config.ImageConfig imageConfig => $"[white]{imageConfig.Identifier}[/]",
                     _ => o as string ?? throw new InvalidOperationException()
                 };
             })

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using port;
 using port.Commands.Commit;
+using port.Commands.Config;
 using port.Commands.Export;
 using port.Commands.Import;
 using port.Commands.List;
@@ -74,6 +75,8 @@ app.Configure(appConfig =>
         .WithAlias("pr");
     appConfig.AddCommand<StopCliCommand>("stop")
         .WithAlias("s");
+    appConfig.AddCommand<ConfigCliCommand>("config")
+        .WithAlias("cfg");
 });
 
 AnsiConsole.Console = new CustomConsole();


### PR DESCRIPTION
The commit ba990479a20acfa759fcbc1dfa784d094a53bc3e adds a cli command to open/show config. When `port config` or `port cfg` without any parameters is called, then just the path to the .port file is printed. If the terminal support links, it is automatically properly formatted/clickable. When the additional parameter `--open` or `-o` is passed, the file is automatically opened with the default application for the file type.

The commit 80f9914f8f19d24a0f3356c93e8b55cf6f299d9a fixing namespaces is not required, but during development in my ide, it always showed errors. If you want, the commit can be removed.