### PR TITLE
Bump Spectre.Console(.Cli) to 0.53.1 (+ CancellationToken migration)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.51.1" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.51.1" />
+    <PackageVersion Include="Spectre.Console" Version="0.53.1" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="yamldotnet" Version="16.3.0" />
   </ItemGroup>

--- a/src/port.Cli/Commands/Commit/CommitCliCommand.cs
+++ b/src/port.Cli/Commands/Commit/CommitCliCommand.cs
@@ -11,23 +11,23 @@ public class CommitCliCommand(
     ListCliCommand listCliCommand
 ) : AsyncCommand<CommitSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, CommitSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, CommitSettings settings, CancellationToken cancellationToken)
     {
-        var containerName = await ResolveContainerNameAsync(settings);
+        var containerName = await ResolveContainerNameAsync(settings, cancellationToken);
         var tag = settings.Tag ?? $"{DateTime.Now:yyyyMMddhhmmss}";
         await commitOrchestrator.WithRenderingAsync(o =>
-            o.ExecuteAsync(containerName, tag, settings.Overwrite, settings.Switch)
+            o.ExecuteAsync(containerName, tag, settings.Overwrite, settings.Switch, cancellationToken)
         );
-        await listCliCommand.ExecuteAsync();
+        await listCliCommand.ExecuteAsync(cancellationToken);
         return 0;
     }
 
-    private async Task<string> ResolveContainerNameAsync(IContainerIdentifierSettings settings)
+    private async Task<string> ResolveContainerNameAsync(IContainerIdentifierSettings settings, CancellationToken cancellationToken)
     {
         if (settings.ContainerIdentifier != null)
             return settings.ContainerIdentifier;
 
-        var containers = await getRunningContainersQuery.QueryAsync().ToListAsync();
+        var containers = await getRunningContainersQuery.QueryAsync().ToListAsync(cancellationToken);
         return containerNamePrompt.GetIdentifierOfContainerFromUser(containers, "commit");
     }
 }

--- a/src/port.Cli/Commands/Config/ConfigCliCommand.cs
+++ b/src/port.Cli/Commands/Config/ConfigCliCommand.cs
@@ -7,7 +7,7 @@ namespace port.Commands.Config;
 
 public class ConfigCliCommand(IConfigOrchestrator configOrchestrator) : Command<ConfigSettings>
 {
-    public override int Execute(CommandContext context, ConfigSettings settings)
+    public override int Execute(CommandContext context, ConfigSettings settings, CancellationToken cancellationToken)
     {
         var result = configOrchestrator.Execute();
 

--- a/src/port.Cli/Commands/List/ListCliCommand.cs
+++ b/src/port.Cli/Commands/List/ListCliCommand.cs
@@ -22,7 +22,7 @@ public class ListCliCommand : AsyncCommand<ListSettings>
         return 0;
     }
 
-    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         var result = await _listOrchestrator.WithRenderingAsync(o => o.ExecuteAsync(null, cancellationToken));
         Render(result);

--- a/src/port.Cli/Commands/List/ListCliCommand.cs
+++ b/src/port.Cli/Commands/List/ListCliCommand.cs
@@ -13,18 +13,18 @@ public class ListCliCommand : AsyncCommand<ListSettings>
         _listOrchestrator = listOrchestrator;
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext _, ListSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext _, ListSettings settings, CancellationToken cancellationToken)
     {
         var result = await _listOrchestrator.WithRenderingAsync(o =>
-            o.ExecuteAsync(settings.ImageIdentifier)
+            o.ExecuteAsync(settings.ImageIdentifier, cancellationToken)
         );
         Render(result);
         return 0;
     }
 
-    public async Task ExecuteAsync()
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        var result = await _listOrchestrator.WithRenderingAsync(o => o.ExecuteAsync(null));
+        var result = await _listOrchestrator.WithRenderingAsync(o => o.ExecuteAsync(null, cancellationToken));
         Render(result);
     }
 

--- a/src/port.Cli/Commands/Prune/PruneCliCommand.cs
+++ b/src/port.Cli/Commands/Prune/PruneCliCommand.cs
@@ -19,10 +19,10 @@ public class PruneCliCommand : AsyncCommand<PruneSettings>
         _listCliCommand = listCliCommand;
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, PruneSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, PruneSettings settings, CancellationToken cancellationToken)
     {
         var result = await _pruneOrchestrator.WithRenderingAsync(o =>
-            o.ExecuteAsync(settings.ImageIdentifier)
+            o.ExecuteAsync(settings.ImageIdentifier, cancellationToken)
         );
 
         if (result.Removals.Count == 0)
@@ -41,7 +41,7 @@ public class PruneCliCommand : AsyncCommand<PruneSettings>
         var removed = result.Removals.Count(r => r.Successful);
         AnsiConsole.MarkupLine($"[green]Pruned {removed} image(s)[/]");
 
-        await _listCliCommand.ExecuteAsync();
+        await _listCliCommand.ExecuteAsync(cancellationToken);
         return 0;
     }
 }

--- a/src/port.Cli/Commands/Pull/PullCliCommand.cs
+++ b/src/port.Cli/Commands/Pull/PullCliCommand.cs
@@ -9,10 +9,10 @@ public class PullCliCommand(
     IPullOrchestrator pullOrchestrator
 ) : AsyncCommand<PullSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, PullSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, PullSettings settings, CancellationToken cancellationToken)
     {
         var (identifier, tag) = await ResolveIdentifierAndTagAsync(settings);
-        await pullOrchestrator.WithProgressAsync(o => o.ExecuteAsync(identifier, tag));
+        await pullOrchestrator.WithProgressAsync(o => o.ExecuteAsync(identifier, tag, cancellationToken));
         return 0;
     }
 

--- a/src/port.Cli/Commands/Remove/RemoveCliCommand.cs
+++ b/src/port.Cli/Commands/Remove/RemoveCliCommand.cs
@@ -25,11 +25,11 @@ public class RemoveCliCommand : AsyncCommand<RemoveSettings>
         _listCliCommand = listCliCommand;
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, RemoveSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, RemoveSettings settings, CancellationToken cancellationToken)
     {
         var (identifier, tag) = await ResolveIdentifierAndTagAsync(settings);
         var result = await _removeOrchestrator.WithRenderingAsync(o =>
-            o.ExecuteAsync(identifier, tag, settings.Recursive)
+            o.ExecuteAsync(identifier, tag, settings.Recursive, cancellationToken)
         );
 
         foreach (var failure in result.Removals.Where(r => !r.Successful))
@@ -43,7 +43,7 @@ public class RemoveCliCommand : AsyncCommand<RemoveSettings>
                 );
         }
 
-        await _listCliCommand.ExecuteAsync();
+        await _listCliCommand.ExecuteAsync(cancellationToken);
         return 0;
     }
 

--- a/src/port.Cli/Commands/Reset/ResetCliCommand.cs
+++ b/src/port.Cli/Commands/Reset/ResetCliCommand.cs
@@ -11,20 +11,20 @@ public class ResetCliCommand(
     ListCliCommand listCliCommand
 ) : AsyncCommand<ResetSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, ResetSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, ResetSettings settings, CancellationToken cancellationToken)
     {
-        var containerName = await ResolveContainerNameAsync(settings);
-        await resetOrchestrator.WithRenderingAsync(o => o.ExecuteAsync(containerName));
-        await listCliCommand.ExecuteAsync();
+        var containerName = await ResolveContainerNameAsync(settings, cancellationToken);
+        await resetOrchestrator.WithRenderingAsync(o => o.ExecuteAsync(containerName, cancellationToken));
+        await listCliCommand.ExecuteAsync(cancellationToken);
         return 0;
     }
 
-    private async Task<string> ResolveContainerNameAsync(IContainerIdentifierSettings settings)
+    private async Task<string> ResolveContainerNameAsync(IContainerIdentifierSettings settings, CancellationToken cancellationToken)
     {
         if (settings.ContainerIdentifier != null)
             return settings.ContainerIdentifier;
 
-        var containers = await getRunningContainersQuery.QueryAsync().ToListAsync();
+        var containers = await getRunningContainersQuery.QueryAsync().ToListAsync(cancellationToken);
         if (containers.Count == 1)
             return containers.Single().ContainerName;
 

--- a/src/port.Cli/Commands/Run/RunCliCommand.cs
+++ b/src/port.Cli/Commands/Run/RunCliCommand.cs
@@ -11,16 +11,16 @@ public class RunCliCommand(
     ListCliCommand listCliCommand
 ) : AsyncCommand<RunSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, RunSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, RunSettings settings, CancellationToken cancellationToken)
     {
         var (identifier, tag) = await ResolveIdentifierAndTagAsync(settings);
         if (tag == null)
             throw new InvalidOperationException("Can not launch untagged image");
 
         await runOrchestrator.WithProgressAsync(o =>
-            o.ExecuteAsync(identifier, tag, settings.Reset)
+            o.ExecuteAsync(identifier, tag, settings.Reset, cancellationToken)
         );
-        await listCliCommand.ExecuteAsync();
+        await listCliCommand.ExecuteAsync(cancellationToken);
         return 0;
     }
 

--- a/src/port.Cli/Commands/Stop/StopCliCommand.cs
+++ b/src/port.Cli/Commands/Stop/StopCliCommand.cs
@@ -24,20 +24,20 @@ public class StopCliCommand : AsyncCommand<StopSettings>
         _listCliCommand = listCliCommand;
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, StopSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, StopSettings settings, CancellationToken cancellationToken)
     {
-        var containerName = await ResolveContainerNameAsync(settings);
-        await _stopOrchestrator.WithRenderingAsync(o => o.ExecuteAsync(containerName));
-        await _listCliCommand.ExecuteAsync();
+        var containerName = await ResolveContainerNameAsync(settings, cancellationToken);
+        await _stopOrchestrator.WithRenderingAsync(o => o.ExecuteAsync(containerName, cancellationToken));
+        await _listCliCommand.ExecuteAsync(cancellationToken);
         return 0;
     }
 
-    private async Task<string> ResolveContainerNameAsync(IContainerIdentifierSettings settings)
+    private async Task<string> ResolveContainerNameAsync(IContainerIdentifierSettings settings, CancellationToken cancellationToken)
     {
         if (settings.ContainerIdentifier != null)
             return settings.ContainerIdentifier;
 
-        var containers = await _getRunningContainersQuery.QueryAsync().ToListAsync();
+        var containers = await _getRunningContainersQuery.QueryAsync().ToListAsync(cancellationToken);
         return _containerNamePrompt.GetIdentifierOfContainerFromUser(containers, "stop");
     }
 }

--- a/src/port.Core/AllImagesQuery.cs
+++ b/src/port.Core/AllImagesQuery.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 
@@ -20,26 +21,32 @@ public class AllImagesQuery : IAllImagesQuery
         _getContainersQuery = getContainersQuery;
     }
 
-    public async IAsyncEnumerable<ImageGroup> QueryAsync()
+    public async IAsyncEnumerable<ImageGroup> QueryAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
     {
         var imageConfigs = _config.ImageConfigs;
 
         foreach (var imageConfig in imageConfigs)
         {
-            var images = await QueryByImageConfigAsync(imageConfig, imageConfigs);
+            var images = await QueryByImageConfigAsync(imageConfig, imageConfigs, cancellationToken);
             yield return CreateImageGroup(images, imageConfig);
         }
     }
 
-    public async IAsyncEnumerable<(string Id, string ParentId)> QueryAllImagesWithParentAsync()
+    public async IAsyncEnumerable<(string Id, string ParentId)> QueryAllImagesWithParentAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
     {
         var imagesListResponses = await _dockerClient.Images.ListImagesAsync(
-            new ImagesListParameters()
+            new ImagesListParameters(),
+            cancellationToken
         );
         foreach (var imagesListResponse in imagesListResponses)
         {
             var imageInspectResult = await _dockerClient.Images.InspectImageAsync(
-                imagesListResponse.ID
+                imagesListResponse.ID,
+                cancellationToken
             );
             if (imageInspectResult.Parent is not null)
             {
@@ -49,29 +56,41 @@ public class AllImagesQuery : IAllImagesQuery
     }
 
     public async Task<List<Image>> QueryByImageConfigAsync(
-        port.Config.Config.ImageConfig imageConfig
-    ) => await QueryByImageConfigAsync(imageConfig, _config.ImageConfigs);
+        port.Config.Config.ImageConfig imageConfig,
+        CancellationToken cancellationToken = default
+    ) => await QueryByImageConfigAsync(imageConfig, _config.ImageConfigs, cancellationToken);
 
     private async Task<List<Image>> QueryByImageConfigAsync(
         port.Config.Config.ImageConfig imageConfig,
-        IReadOnlyCollection<port.Config.Config.ImageConfig> imageConfigs
+        IReadOnlyCollection<port.Config.Config.ImageConfig> imageConfigs,
+        CancellationToken cancellationToken
     )
     {
-        var imagesListResponses = await GetImagesByNameAsync(imageConfig.ImageName);
+        var imagesListResponses = await GetImagesByNameAsync(
+            imageConfig.ImageName,
+            cancellationToken
+        );
         var danglingImages = await GetDanglingImagesByNameAsync(
             imageConfig.ImageName,
-            imageConfig.Identifier
+            imageConfig.Identifier,
+            cancellationToken
         );
         var allImagesListResponses = imagesListResponses
             .Concat(danglingImages.Where(d => imagesListResponses.All(i => i.ID != d.ID)))
             .ToList();
         var images = await GetAllTagsAsync(imageConfig, imageConfigs, allImagesListResponses)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
         images.AddRange(
-            await GetSnapshotImagesAsync(imageConfigs, imageConfig, allImagesListResponses)
+            await GetSnapshotImagesAsync(
+                imageConfigs,
+                imageConfig,
+                allImagesListResponses,
+                cancellationToken
+            )
         );
         images.AddRange(
-            await GetUntaggedImagesAsync(imageConfig, allImagesListResponses).ToListAsync()
+            await GetUntaggedImagesAsync(imageConfig, allImagesListResponses)
+                .ToListAsync(cancellationToken)
         );
         return images;
     }
@@ -106,7 +125,8 @@ public class AllImagesQuery : IAllImagesQuery
     private async Task<IEnumerable<Image>> GetSnapshotImagesAsync(
         IReadOnlyCollection<Config.Config.ImageConfig> imageConfigs,
         Config.Config.ImageConfig imageConfig,
-        IEnumerable<ImagesListResponse> imagesListResponses
+        IEnumerable<ImagesListResponse> imagesListResponses,
+        CancellationToken cancellationToken
     )
     {
         return (
@@ -116,10 +136,17 @@ public class AllImagesQuery : IAllImagesQuery
                     .Where(imagesListResponse => IsNotBase(imageConfigs, imagesListResponse))
                     .Select(async imagesListResponse =>
                     {
-                        if (!await IsSnapshotOfBaseAsync(imageConfig, imagesListResponse))
+                        if (
+                            !await IsSnapshotOfBaseAsync(
+                                imageConfig,
+                                imagesListResponse,
+                                cancellationToken
+                            )
+                        )
                             return null;
                         var imageInspectResponse = await _dockerClient.Images.InspectImageAsync(
-                            imagesListResponse.ID
+                            imagesListResponse.ID,
+                            cancellationToken
                         );
                         var labels =
                             imageInspectResponse.Config?.Labels
@@ -135,7 +162,7 @@ public class AllImagesQuery : IAllImagesQuery
                             tag = tag[tagPrefix.Length..];
                         var containers = await _getContainersQuery
                             .QueryByImageIdAsync(imagesListResponse.ID)
-                            .ToListAsync();
+                            .ToListAsync(cancellationToken);
                         return new Image(labels)
                         {
                             Name = imageName,
@@ -166,7 +193,8 @@ public class AllImagesQuery : IAllImagesQuery
     private async IAsyncEnumerable<Image> GetAllTagsAsync(
         Config.Config.ImageConfig imageConfig,
         IReadOnlyCollection<Config.Config.ImageConfig> imageConfigs,
-        IList<ImagesListResponse> imagesListResponses
+        IList<ImagesListResponse> imagesListResponses,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
         var yieldedTags = new HashSet<string>();
@@ -187,7 +215,7 @@ public class AllImagesQuery : IAllImagesQuery
             {
                 containers = await _getContainersQuery
                     .QueryByImageIdAsync(imagesListResponse.ID)
-                    .ToListAsync();
+                    .ToListAsync(cancellationToken);
                 yieldedImageIds.Add(imagesListResponse.ID);
             }
             else
@@ -198,7 +226,10 @@ public class AllImagesQuery : IAllImagesQuery
             var cleanedTag = tag;
             var imageInspectResponse =
                 imagesListResponse != null
-                    ? await _dockerClient.Images.InspectImageAsync(imagesListResponse.ID)
+                    ? await _dockerClient.Images.InspectImageAsync(
+                        imagesListResponse.ID,
+                        cancellationToken
+                    )
                     : null;
             var labels = imageInspectResponse?.Config?.Labels ?? new Dictionary<string, string>();
             var tagPrefix = labels
@@ -233,7 +264,8 @@ public class AllImagesQuery : IAllImagesQuery
             if (IsNotBase(imageConfigs, imagesListResponse))
             {
                 var imageInspectResponse = await _dockerClient.Images.InspectImageAsync(
-                    imagesListResponse.ID
+                    imagesListResponse.ID,
+                    cancellationToken
                 );
                 var snapshotIdentifier = imageInspectResponse
                     .Config.Labels?.Where(l => l.Key == Constants.IdentifierLabel)
@@ -263,9 +295,10 @@ public class AllImagesQuery : IAllImagesQuery
 
                 var containers = await _getContainersQuery
                     .QueryByImageIdAsync(imagesListResponse.ID)
-                    .ToListAsync();
+                    .ToListAsync(cancellationToken);
                 var imageInspectResponse = await _dockerClient.Images.InspectImageAsync(
-                    imagesListResponse.ID
+                    imagesListResponse.ID,
+                    cancellationToken
                 );
                 var labels =
                     imageInspectResponse.Config?.Labels ?? new Dictionary<string, string>();
@@ -294,7 +327,8 @@ public class AllImagesQuery : IAllImagesQuery
 
     private async IAsyncEnumerable<Image> GetUntaggedImagesAsync(
         Config.Config.ImageConfig imageConfig,
-        IEnumerable<ImagesListResponse> imagesListResponses
+        IEnumerable<ImagesListResponse> imagesListResponses,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
         foreach (var imagesListResponse in imagesListResponses.Where(IsUntagged))
@@ -312,9 +346,10 @@ public class AllImagesQuery : IAllImagesQuery
 
             var containers = await _getContainersQuery
                 .QueryByImageIdAsync(imagesListResponse.ID)
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
             var imageInspectResponse = await _dockerClient.Images.InspectImageAsync(
-                imagesListResponse.ID
+                imagesListResponse.ID,
+                cancellationToken
             );
             var originalTag = containers
                 .Select(c => c.GetLabel(Constants.BaseTagLabel))
@@ -336,23 +371,30 @@ public class AllImagesQuery : IAllImagesQuery
         }
     }
 
-    private async Task<IList<ImagesListResponse>> GetImagesByNameAsync(string imageName)
+    private async Task<IList<ImagesListResponse>> GetImagesByNameAsync(
+        string imageName,
+        CancellationToken cancellationToken
+    )
     {
         var parameters = new ImagesListParameters
         {
             Filters = new Dictionary<string, IDictionary<string, bool>>(),
         };
         parameters.Filters.Add("reference", new Dictionary<string, bool> { { imageName, true } });
-        return await _dockerClient.Images.ListImagesAsync(parameters);
+        return await _dockerClient.Images.ListImagesAsync(parameters, cancellationToken);
     }
 
     private async Task<IList<ImagesListResponse>> GetDanglingImagesByNameAsync(
         string imageName,
-        string identifier
+        string identifier,
+        CancellationToken cancellationToken
     )
     {
         // Query all images (not just dangling) to also catch untagged images that still have RepoDigests
-        var allImages = await _dockerClient.Images.ListImagesAsync(new ImagesListParameters());
+        var allImages = await _dockerClient.Images.ListImagesAsync(
+            new ImagesListParameters(),
+            cancellationToken
+        );
 
         var result = new List<ImagesListResponse>();
         foreach (var image in allImages.Where(IsUntagged))
@@ -368,7 +410,9 @@ public class AllImagesQuery : IAllImagesQuery
             }
 
             // Match by containers with matching identifier
-            var containers = await _getContainersQuery.QueryByImageIdAsync(image.ID).ToListAsync();
+            var containers = await _getContainersQuery
+                .QueryByImageIdAsync(image.ID)
+                .ToListAsync(cancellationToken);
             if (containers.Any(c => c.ContainerIdentifier == identifier))
             {
                 result.Add(image);
@@ -409,7 +453,8 @@ public class AllImagesQuery : IAllImagesQuery
 
     private async Task<bool> IsSnapshotOfBaseAsync(
         port.Config.Config.ImageConfig imageConfig,
-        ImagesListResponse e
+        ImagesListResponse e,
+        CancellationToken cancellationToken
     )
     {
         var imageNameAndTags = imageConfig
@@ -417,7 +462,10 @@ public class AllImagesQuery : IAllImagesQuery
             .Select(imageConfig1 =>
                 ImageNameHelper.BuildImageName(imageConfig1.ImageName, imageConfig1.tag)
             );
-        var imageInspectResponse = await _dockerClient.Images.InspectImageAsync(e.ID);
+        var imageInspectResponse = await _dockerClient.Images.InspectImageAsync(
+            e.ID,
+            cancellationToken
+        );
         var identifier = imageInspectResponse
             .Config.Labels?.Where(l => l.Key == Constants.IdentifierLabel)
             .Select(l => l.Value)

--- a/src/port.Core/AllImagesQuery.cs
+++ b/src/port.Core/AllImagesQuery.cs
@@ -57,7 +57,7 @@ public class AllImagesQuery : IAllImagesQuery
 
     public async Task<List<Image>> QueryByImageConfigAsync(
         port.Config.Config.ImageConfig imageConfig,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     ) => await QueryByImageConfigAsync(imageConfig, _config.ImageConfigs, cancellationToken);
 
     private async Task<List<Image>> QueryByImageConfigAsync(

--- a/src/port.Core/CreateContainerCommand.cs
+++ b/src/port.Core/CreateContainerCommand.cs
@@ -21,14 +21,15 @@ public class CreateContainerCommand : ICreateContainerCommand
         string? tagPrefix,
         string? tag,
         IEnumerable<string> ports,
-        IList<string> environment
+        IList<string> environment,
+        CancellationToken cancellationToken
     )
     {
         var portBindings = ports
             .Select(e => e.Split(PortSeparator))
             .ToDictionary(e => e[1], e => CreateHostPortList(e[0]));
         var containerName = ContainerNameHelper.BuildContainerName(containerIdentifier, tag);
-        var image = await _getImageQuery.QueryAsync(imageIdentifier, tag);
+        var image = await _getImageQuery.QueryAsync(imageIdentifier, tag, cancellationToken);
         var baseTag = image?.GetLabel(Constants.BaseTagLabel) ?? image?.BaseImage?.Tag ?? tag;
         var labels = new Dictionary<string, string>
         {
@@ -47,12 +48,18 @@ public class CreateContainerCommand : ICreateContainerCommand
                 HostConfig = new HostConfig { PortBindings = portBindings },
                 ExposedPorts = portBindings.Keys.ToDictionary(port => port, _ => new EmptyStruct()),
                 Labels = labels,
-            }
+            },
+            cancellationToken
         );
         return createContainerResponse.ID;
     }
 
-    public async Task<string> ExecuteAsync(Container container, string tagPrefix, string newTag)
+    public async Task<string> ExecuteAsync(
+        Container container,
+        string tagPrefix,
+        string newTag,
+        CancellationToken cancellationToken
+    )
     {
         var portBindings = container.PortBindings;
         var environment = container.Environment;
@@ -76,12 +83,13 @@ public class CreateContainerCommand : ICreateContainerCommand
                 Env = environment,
                 ExposedPorts = portBindings.Keys.ToDictionary(port => port, _ => new EmptyStruct()),
                 Labels = labels,
-            }
+            },
+            cancellationToken
         );
         return createContainerResponse.ID;
     }
 
-    public async Task<string> ExecuteAsync(Container container)
+    public async Task<string> ExecuteAsync(Container container, CancellationToken cancellationToken)
     {
         var portBindings = container.PortBindings;
         var environment = container.Environment;
@@ -104,7 +112,8 @@ public class CreateContainerCommand : ICreateContainerCommand
                 Env = environment,
                 ExposedPorts = portBindings.Keys.ToDictionary(port => port, _ => new EmptyStruct()),
                 Labels = labels,
-            }
+            },
+            cancellationToken
         );
         return createContainerResponse.ID;
     }

--- a/src/port.Core/CreateImageCommand.cs
+++ b/src/port.Core/CreateImageCommand.cs
@@ -19,7 +19,7 @@ public class CreateImageCommand : ICreateImageCommand
         _progressSubscriber = progressSubscriber;
     }
 
-    public async Task ExecuteAsync(string imageName, string? tag)
+    public async Task ExecuteAsync(string imageName, string? tag, CancellationToken cancellationToken)
     {
         var progress = new Progress<JSONMessage>();
 
@@ -27,7 +27,8 @@ public class CreateImageCommand : ICreateImageCommand
         await _dockerClient.Images.CreateImageAsync(
             new ImagesCreateParameters { FromImage = imageName, Tag = tag },
             null,
-            progress
+            progress,
+            cancellationToken
         );
     }
 }

--- a/src/port.Core/CreateImageFromContainerCommand.cs
+++ b/src/port.Core/CreateImageFromContainerCommand.cs
@@ -10,7 +10,8 @@ public class CreateImageFromContainerCommand(IDockerClient dockerClient)
         Container container,
         string imageName,
         string tagPrefix,
-        string newTag
+        string newTag,
+        CancellationToken cancellationToken
     )
     {
         var labels = new Dictionary<string, string>();
@@ -30,7 +31,8 @@ public class CreateImageFromContainerCommand(IDockerClient dockerClient)
                 RepositoryName = imageName,
                 Tag = newTag,
                 Config = new Docker.DotNet.Models.Config { Labels = labels },
-            }
+            },
+            cancellationToken
         );
         return newTag;
     }

--- a/src/port.Core/DoesImageExistQuery.cs
+++ b/src/port.Core/DoesImageExistQuery.cs
@@ -15,7 +15,7 @@ public class DoesImageExistQuery : IDoesImageExistQuery
     public async Task<bool> QueryAsync(
         string imageName,
         string? tag,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     )
     {
         var parameters = new ImagesListParameters

--- a/src/port.Core/DoesImageExistQuery.cs
+++ b/src/port.Core/DoesImageExistQuery.cs
@@ -12,14 +12,21 @@ public class DoesImageExistQuery : IDoesImageExistQuery
         _dockerClient = dockerClient;
     }
 
-    public async Task<bool> QueryAsync(string imageName, string? tag)
+    public async Task<bool> QueryAsync(
+        string imageName,
+        string? tag,
+        CancellationToken cancellationToken = default
+    )
     {
         var parameters = new ImagesListParameters
         {
             Filters = new Dictionary<string, IDictionary<string, bool>>(),
         };
         parameters.Filters.Add("reference", new Dictionary<string, bool> { { imageName, true } });
-        var imagesListResponses = await _dockerClient.Images.ListImagesAsync(parameters);
+        var imagesListResponses = await _dockerClient.Images.ListImagesAsync(
+            parameters,
+            cancellationToken
+        );
         var fullName = ImageNameHelper.BuildImageName(imageName, tag);
         return imagesListResponses.Any(e =>
             tag == null && !e.RepoTags.Any()

--- a/src/port.Core/GetContainersQuery.cs
+++ b/src/port.Core/GetContainersQuery.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Runtime.CompilerServices;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 using DotNext.Threading;
@@ -23,10 +24,12 @@ public class GetContainersQuery : IGetContainersQuery
         });
     }
 
-    public async IAsyncEnumerable<Container> QueryRunningAsync()
+    public async IAsyncEnumerable<Container> QueryRunningAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
     {
         var containerListResponses = await _containerListResponses.WithCancellation(
-            CancellationToken.None
+            cancellationToken
         );
         foreach (var containerListResponse in containerListResponses)
         {
@@ -34,7 +37,8 @@ public class GetContainersQuery : IGetContainersQuery
             try
             {
                 inspectContainerResponse = await _dockerClient.Containers.InspectContainerAsync(
-                    containerListResponse.ID
+                    containerListResponse.ID,
+                    cancellationToken
                 );
             }
             catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
@@ -52,11 +56,12 @@ public class GetContainersQuery : IGetContainersQuery
 
     public async IAsyncEnumerable<Container> QueryByContainerIdentifierAndTagAsync(
         string containerIdentifier,
-        string? tag
+        string? tag,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
         var containerListResponses = await _containerListResponses.WithCancellation(
-            CancellationToken.None
+            cancellationToken
         );
         foreach (var containerListResponse in containerListResponses)
         {
@@ -64,7 +69,8 @@ public class GetContainersQuery : IGetContainersQuery
             try
             {
                 inspectContainerResponse = await _dockerClient.Containers.InspectContainerAsync(
-                    containerListResponse.ID
+                    containerListResponse.ID,
+                    cancellationToken
                 );
             }
             catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
@@ -83,10 +89,13 @@ public class GetContainersQuery : IGetContainersQuery
         }
     }
 
-    public async IAsyncEnumerable<Container> QueryByImageIdAsync(string imageId)
+    public async IAsyncEnumerable<Container> QueryByImageIdAsync(
+        string imageId,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
     {
         var containerListResponses = await _containerListResponses.WithCancellation(
-            CancellationToken.None
+            cancellationToken
         );
         foreach (var containerListResponse in containerListResponses)
         {
@@ -96,7 +105,8 @@ public class GetContainersQuery : IGetContainersQuery
             try
             {
                 inspectContainerResponse = await _dockerClient.Containers.InspectContainerAsync(
-                    containerListResponse.ID
+                    containerListResponse.ID,
+                    cancellationToken
                 );
             }
             catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
@@ -109,10 +119,13 @@ public class GetContainersQuery : IGetContainersQuery
         }
     }
 
-    public async IAsyncEnumerable<Container> QueryByContainerNameAsync(string containerName)
+    public async IAsyncEnumerable<Container> QueryByContainerNameAsync(
+        string containerName,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
     {
         var containerListResponses = await _containerListResponses.WithCancellation(
-            CancellationToken.None
+            cancellationToken
         );
         foreach (var containerListResponse in containerListResponses)
         {
@@ -120,7 +133,8 @@ public class GetContainersQuery : IGetContainersQuery
             try
             {
                 inspectContainerResponse = await _dockerClient.Containers.InspectContainerAsync(
-                    containerListResponse.ID
+                    containerListResponse.ID,
+                    cancellationToken
                 );
             }
             catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.NotFound)

--- a/src/port.Core/GetDigestsByIdQuery.cs
+++ b/src/port.Core/GetDigestsByIdQuery.cs
@@ -12,13 +12,19 @@ public class GetDigestsByIdQuery : IGetDigestsByIdQuery
         _dockerClient = dockerClient;
     }
 
-    public async Task<IList<string>?> QueryAsync(string imageId)
+    public async Task<IList<string>?> QueryAsync(
+        string imageId,
+        CancellationToken cancellationToken = default
+    )
     {
         var parameters = new ImagesListParameters
         {
             Filters = new Dictionary<string, IDictionary<string, bool>>(),
         };
-        var imagesListResponses = await _dockerClient.Images.ListImagesAsync(parameters);
+        var imagesListResponses = await _dockerClient.Images.ListImagesAsync(
+            parameters,
+            cancellationToken
+        );
         var imagesListResponse = imagesListResponses.SingleOrDefault(e => e.ID == imageId);
         return imagesListResponse?.RepoDigests;
     }

--- a/src/port.Core/GetDigestsByIdQuery.cs
+++ b/src/port.Core/GetDigestsByIdQuery.cs
@@ -14,7 +14,7 @@ public class GetDigestsByIdQuery : IGetDigestsByIdQuery
 
     public async Task<IList<string>?> QueryAsync(
         string imageId,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     )
     {
         var parameters = new ImagesListParameters

--- a/src/port.Core/GetImageIdQuery.cs
+++ b/src/port.Core/GetImageIdQuery.cs
@@ -12,13 +12,20 @@ public class GetImageIdQuery : IGetImageIdQuery
         _dockerClient = dockerClient;
     }
 
-    public async Task<IEnumerable<string>> QueryAsync(string imageName, string? tag)
+    public async Task<IEnumerable<string>> QueryAsync(
+        string imageName,
+        string? tag,
+        CancellationToken cancellationToken = default
+    )
     {
         if (tag != null && ImageNameHelper.IsDigest(tag))
         {
             try
             {
-                var inspectResponse = await _dockerClient.Images.InspectImageAsync(tag);
+                var inspectResponse = await _dockerClient.Images.InspectImageAsync(
+                    tag,
+                    cancellationToken
+                );
                 return [inspectResponse.ID];
             }
             catch (DockerImageNotFoundException)
@@ -32,7 +39,10 @@ public class GetImageIdQuery : IGetImageIdQuery
             Filters = new Dictionary<string, IDictionary<string, bool>>(),
         };
         parameters.Filters.Add("reference", new Dictionary<string, bool> { { imageName, true } });
-        var imagesListResponses = await _dockerClient.Images.ListImagesAsync(parameters);
+        var imagesListResponses = await _dockerClient.Images.ListImagesAsync(
+            parameters,
+            cancellationToken
+        );
         var fullName = ImageNameHelper.BuildImageName(imageName, tag);
         return imagesListResponses
             .Where(e =>

--- a/src/port.Core/GetImageIdQuery.cs
+++ b/src/port.Core/GetImageIdQuery.cs
@@ -15,7 +15,7 @@ public class GetImageIdQuery : IGetImageIdQuery
     public async Task<IEnumerable<string>> QueryAsync(
         string imageName,
         string? tag,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     )
     {
         if (tag != null && ImageNameHelper.IsDigest(tag))

--- a/src/port.Core/GetImageQuery.cs
+++ b/src/port.Core/GetImageQuery.cs
@@ -17,7 +17,7 @@ public class GetImageQuery : IGetImageQuery
     public async Task<Image?> QueryAsync(
         string imageName,
         string? tag,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     )
     {
         var parameters = new ImagesListParameters

--- a/src/port.Core/GetImageQuery.cs
+++ b/src/port.Core/GetImageQuery.cs
@@ -14,14 +14,21 @@ public class GetImageQuery : IGetImageQuery
         _getContainersQuery = getContainersQuery;
     }
 
-    public async Task<Image?> QueryAsync(string imageName, string? tag)
+    public async Task<Image?> QueryAsync(
+        string imageName,
+        string? tag,
+        CancellationToken cancellationToken = default
+    )
     {
         var parameters = new ImagesListParameters
         {
             Filters = new Dictionary<string, IDictionary<string, bool>>(),
         };
         parameters.Filters.Add("reference", new Dictionary<string, bool> { { imageName, true } });
-        var imagesListResponses = await _dockerClient.Images.ListImagesAsync(parameters);
+        var imagesListResponses = await _dockerClient.Images.ListImagesAsync(
+            parameters,
+            cancellationToken
+        );
         var fullName = ImageNameHelper.BuildImageName(imageName, tag);
         var imagesListResponse = imagesListResponses.SingleOrDefault(e =>
             tag == null && !e.RepoTags.Any()
@@ -34,16 +41,18 @@ public class GetImageQuery : IGetImageQuery
 
         var containers = await _getContainersQuery
             .QueryByImageIdAsync(imagesListResponse.ID)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
         var imageInspectResponse = await _dockerClient.Images.InspectImageAsync(
-            imagesListResponse.ID
+            imagesListResponse.ID,
+            cancellationToken
         );
         return await ConvertToImage(
             imageInspectResponse.Config.Labels,
             imageName,
             tag,
             imagesListResponse,
-            containers
+            containers,
+            cancellationToken
         );
     }
 
@@ -52,11 +61,13 @@ public class GetImageQuery : IGetImageQuery
         string imageName,
         string? tag,
         ImagesListResponse imagesListResponse,
-        IReadOnlyCollection<Container> containers
+        IReadOnlyCollection<Container> containers,
+        CancellationToken cancellationToken
     )
     {
         var imageInspectResult = await _dockerClient.Images.InspectImageAsync(
-            imagesListResponse.ID
+            imagesListResponse.ID,
+            cancellationToken
         );
         return new Image(labels ?? new Dictionary<string, string>())
         {
@@ -74,14 +85,19 @@ public class GetImageQuery : IGetImageQuery
                 : imageInspectResult.Parent,
             Parent = string.IsNullOrEmpty(imageInspectResult.Parent)
                 ? null
-                : await QueryParent(imageInspectResult.Parent, containers),
+                : await QueryParent(imageInspectResult.Parent, containers, cancellationToken),
         };
     }
 
-    private async Task<Image?> QueryParent(string id, IReadOnlyCollection<Container> containers)
+    private async Task<Image?> QueryParent(
+        string id,
+        IReadOnlyCollection<Container> containers,
+        CancellationToken cancellationToken
+    )
     {
         var imagesListResponses = await _dockerClient.Images.ListImagesAsync(
-            new ImagesListParameters()
+            new ImagesListParameters(),
+            cancellationToken
         );
 
         var imagesListResponse = imagesListResponses.SingleOrDefault(e => e.ID == id);
@@ -92,7 +108,8 @@ public class GetImageQuery : IGetImageQuery
         }
 
         var imageInspectResponse = await _dockerClient.Images.InspectImageAsync(
-            imagesListResponse.ID
+            imagesListResponse.ID,
+            cancellationToken
         );
         var labels = imageInspectResponse.Config.Labels;
 
@@ -108,7 +125,8 @@ public class GetImageQuery : IGetImageQuery
                     imageName1,
                     tag,
                     imagesListResponse,
-                    containers
+                    containers,
+                    cancellationToken
                 );
             }
 
@@ -122,7 +140,8 @@ public class GetImageQuery : IGetImageQuery
                         imageName1,
                         tag,
                         imagesListResponse,
-                        containers
+                        containers,
+                        cancellationToken
                     );
             }
         }
@@ -134,7 +153,8 @@ public class GetImageQuery : IGetImageQuery
                 nameNameAndId.imageName,
                 null,
                 imagesListResponse,
-                containers
+                containers,
+                cancellationToken
             );
 
         return null;

--- a/src/port.Core/GetRunningContainersQuery.cs
+++ b/src/port.Core/GetRunningContainersQuery.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Runtime.CompilerServices;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 
@@ -15,13 +16,16 @@ public class GetRunningContainersQuery : IGetRunningContainersQuery
         _config = config;
     }
 
-    public async IAsyncEnumerable<Container> QueryAsync()
+    public async IAsyncEnumerable<Container> QueryAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
     {
         var images = _config.ImageConfigs;
         var identifiers = images.Select(image => image.Identifier).ToHashSet();
 
         var containerListResponses = await _dockerClient.Containers.ListContainersAsync(
-            new ContainersListParameters { Limit = long.MaxValue }
+            new ContainersListParameters { Limit = long.MaxValue },
+            cancellationToken
         );
         foreach (var containerListResponse in containerListResponses)
         {
@@ -29,7 +33,8 @@ public class GetRunningContainersQuery : IGetRunningContainersQuery
             try
             {
                 inspectContainerResponse = await _dockerClient.Containers.InspectContainerAsync(
-                    containerListResponse.ID
+                    containerListResponse.ID,
+                    cancellationToken
                 );
             }
             catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.NotFound)

--- a/src/port.Core/IAllImagesQuery.cs
+++ b/src/port.Core/IAllImagesQuery.cs
@@ -10,6 +10,6 @@ public interface IAllImagesQuery
     );
     Task<List<Image>> QueryByImageConfigAsync(
         port.Config.Config.ImageConfig imageConfig,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     );
 }

--- a/src/port.Core/IAllImagesQuery.cs
+++ b/src/port.Core/IAllImagesQuery.cs
@@ -4,7 +4,12 @@ namespace port;
 
 public interface IAllImagesQuery
 {
-    IAsyncEnumerable<ImageGroup> QueryAsync();
-    IAsyncEnumerable<(string Id, string ParentId)> QueryAllImagesWithParentAsync();
-    Task<List<Image>> QueryByImageConfigAsync(port.Config.Config.ImageConfig imageConfig);
+    IAsyncEnumerable<ImageGroup> QueryAsync(CancellationToken cancellationToken = default);
+    IAsyncEnumerable<(string Id, string ParentId)> QueryAllImagesWithParentAsync(
+        CancellationToken cancellationToken = default
+    );
+    Task<List<Image>> QueryByImageConfigAsync(
+        port.Config.Config.ImageConfig imageConfig,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/port.Core/ICreateContainerCommand.cs
+++ b/src/port.Core/ICreateContainerCommand.cs
@@ -8,8 +8,14 @@ public interface ICreateContainerCommand
         string? tagPrefix,
         string? tag,
         IEnumerable<string> ports,
-        IList<string> environment
+        IList<string> environment,
+        CancellationToken cancellationToken
     );
-    Task<string> ExecuteAsync(Container container, string tagPrefix, string newTag);
-    Task<string> ExecuteAsync(Container container);
+    Task<string> ExecuteAsync(
+        Container container,
+        string tagPrefix,
+        string newTag,
+        CancellationToken cancellationToken
+    );
+    Task<string> ExecuteAsync(Container container, CancellationToken cancellationToken);
 }

--- a/src/port.Core/ICreateImageCommand.cs
+++ b/src/port.Core/ICreateImageCommand.cs
@@ -2,7 +2,7 @@ namespace port;
 
 public interface ICreateImageCommand
 {
-    Task ExecuteAsync(string imageName, string? tag);
+    Task ExecuteAsync(string imageName, string? tag, CancellationToken cancellationToken);
 
     IObservable<Progress> ProgressObservable { get; }
 }

--- a/src/port.Core/ICreateImageFromContainerCommand.cs
+++ b/src/port.Core/ICreateImageFromContainerCommand.cs
@@ -6,6 +6,7 @@ public interface ICreateImageFromContainerCommand
         Container container,
         string imageName,
         string tagPrefix,
-        string newTag
+        string newTag,
+        CancellationToken cancellationToken
     );
 }

--- a/src/port.Core/IDoesImageExistQuery.cs
+++ b/src/port.Core/IDoesImageExistQuery.cs
@@ -2,5 +2,9 @@ namespace port;
 
 public interface IDoesImageExistQuery
 {
-    Task<bool> QueryAsync(string imageName, string? tag);
+    Task<bool> QueryAsync(
+        string imageName,
+        string? tag,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/port.Core/IDoesImageExistQuery.cs
+++ b/src/port.Core/IDoesImageExistQuery.cs
@@ -5,6 +5,6 @@ public interface IDoesImageExistQuery
     Task<bool> QueryAsync(
         string imageName,
         string? tag,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     );
 }

--- a/src/port.Core/IGetContainersQuery.cs
+++ b/src/port.Core/IGetContainersQuery.cs
@@ -2,11 +2,18 @@ namespace port;
 
 public interface IGetContainersQuery
 {
-    IAsyncEnumerable<Container> QueryRunningAsync();
+    IAsyncEnumerable<Container> QueryRunningAsync(CancellationToken cancellationToken = default);
     IAsyncEnumerable<Container> QueryByContainerIdentifierAndTagAsync(
         string containerIdentifier,
-        string? tag
+        string? tag,
+        CancellationToken cancellationToken = default
     );
-    IAsyncEnumerable<Container> QueryByImageIdAsync(string imageId);
-    IAsyncEnumerable<Container> QueryByContainerNameAsync(string containerName);
+    IAsyncEnumerable<Container> QueryByImageIdAsync(
+        string imageId,
+        CancellationToken cancellationToken = default
+    );
+    IAsyncEnumerable<Container> QueryByContainerNameAsync(
+        string containerName,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/port.Core/IGetDigestsByIdQuery.cs
+++ b/src/port.Core/IGetDigestsByIdQuery.cs
@@ -2,5 +2,5 @@ namespace port.Commands.Commit;
 
 public interface IGetDigestsByIdQuery
 {
-    Task<IList<string>?> QueryAsync(string imageId);
+    Task<IList<string>?> QueryAsync(string imageId, CancellationToken cancellationToken = default);
 }

--- a/src/port.Core/IGetDigestsByIdQuery.cs
+++ b/src/port.Core/IGetDigestsByIdQuery.cs
@@ -2,5 +2,5 @@ namespace port.Commands.Commit;
 
 public interface IGetDigestsByIdQuery
 {
-    Task<IList<string>?> QueryAsync(string imageId, CancellationToken cancellationToken = default);
+    Task<IList<string>?> QueryAsync(string imageId, CancellationToken cancellationToken);
 }

--- a/src/port.Core/IGetImageIdQuery.cs
+++ b/src/port.Core/IGetImageIdQuery.cs
@@ -2,5 +2,9 @@ namespace port;
 
 public interface IGetImageIdQuery
 {
-    Task<IEnumerable<string>> QueryAsync(string imageName, string? tag);
+    Task<IEnumerable<string>> QueryAsync(
+        string imageName,
+        string? tag,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/port.Core/IGetImageIdQuery.cs
+++ b/src/port.Core/IGetImageIdQuery.cs
@@ -5,6 +5,6 @@ public interface IGetImageIdQuery
     Task<IEnumerable<string>> QueryAsync(
         string imageName,
         string? tag,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     );
 }

--- a/src/port.Core/IGetImageQuery.cs
+++ b/src/port.Core/IGetImageQuery.cs
@@ -5,6 +5,6 @@ public interface IGetImageQuery
     Task<Image?> QueryAsync(
         string imageName,
         string? tag,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken
     );
 }

--- a/src/port.Core/IGetImageQuery.cs
+++ b/src/port.Core/IGetImageQuery.cs
@@ -2,5 +2,9 @@ namespace port;
 
 public interface IGetImageQuery
 {
-    Task<Image?> QueryAsync(string imageName, string? tag);
+    Task<Image?> QueryAsync(
+        string imageName,
+        string? tag,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/port.Core/IGetRunningContainersQuery.cs
+++ b/src/port.Core/IGetRunningContainersQuery.cs
@@ -2,5 +2,5 @@ namespace port;
 
 public interface IGetRunningContainersQuery
 {
-    IAsyncEnumerable<Container> QueryAsync();
+    IAsyncEnumerable<Container> QueryAsync(CancellationToken cancellationToken = default);
 }

--- a/src/port.Core/IRemoveImageCommand.cs
+++ b/src/port.Core/IRemoveImageCommand.cs
@@ -2,6 +2,6 @@ namespace port;
 
 public interface IRemoveImageCommand
 {
-    Task ExecuteAsync(string imageName, string? tag);
-    Task<ImageRemovalResult> ExecuteAsync(string id);
+    Task ExecuteAsync(string imageName, string? tag, CancellationToken cancellationToken);
+    Task<ImageRemovalResult> ExecuteAsync(string id, CancellationToken cancellationToken);
 }

--- a/src/port.Core/IRemoveImagesCommand.cs
+++ b/src/port.Core/IRemoveImagesCommand.cs
@@ -7,6 +7,6 @@ public interface IRemoveImagesCommand
     Task<List<ImageRemovalResult>> ExecuteAsync(
         List<string> imageIds,
         IObserver<OrchestrationEvent>? events = null,
-        CancellationToken ct = default
+        CancellationToken cancellationToken = default
     );
 }

--- a/src/port.Core/IRenameContainerCommand.cs
+++ b/src/port.Core/IRenameContainerCommand.cs
@@ -2,5 +2,5 @@ namespace port;
 
 public interface IRenameContainerCommand
 {
-    Task ExecuteAsync(string containerId, string newName);
+    Task ExecuteAsync(string containerId, string newName, CancellationToken cancellationToken);
 }

--- a/src/port.Core/IRunContainerCommand.cs
+++ b/src/port.Core/IRunContainerCommand.cs
@@ -2,6 +2,6 @@ namespace port;
 
 public interface IRunContainerCommand
 {
-    Task ExecuteAsync(string id);
-    Task ExecuteAsync(Container container);
+    Task ExecuteAsync(string id, CancellationToken cancellationToken);
+    Task ExecuteAsync(Container container, CancellationToken cancellationToken);
 }

--- a/src/port.Core/IStopAndRemoveContainerCommand.cs
+++ b/src/port.Core/IStopAndRemoveContainerCommand.cs
@@ -2,5 +2,5 @@ namespace port;
 
 public interface IStopAndRemoveContainerCommand
 {
-    Task ExecuteAsync(string containerId);
+    Task ExecuteAsync(string containerId, CancellationToken cancellationToken);
 }

--- a/src/port.Core/IStopContainerCommand.cs
+++ b/src/port.Core/IStopContainerCommand.cs
@@ -2,5 +2,5 @@ namespace port;
 
 public interface IStopContainerCommand
 {
-    public Task ExecuteAsync(string containerId);
+    public Task ExecuteAsync(string containerId, CancellationToken cancellationToken);
 }

--- a/src/port.Core/Orchestrators/CommitOrchestrator.cs
+++ b/src/port.Core/Orchestrators/CommitOrchestrator.cs
@@ -74,7 +74,7 @@ public class CommitOrchestrator : ICommitOrchestrator
         }
         else
         {
-            (imageName, tagPrefix, newTag) = await GetNewTagAsync(container, tag);
+            (imageName, tagPrefix, newTag) = await GetNewTagAsync(container, tag, ct);
         }
 
         _events.OnNext(
@@ -91,12 +91,13 @@ public class CommitOrchestrator : ICommitOrchestrator
             container,
             imageName,
             tagPrefix,
-            newTag
+            newTag,
+            ct
         );
 
         _events.OnNext(new StatusEvent($"Removing containers named '{container.ContainerName}'"));
         await Task.WhenAll(
-            containerWithSameTag.Select(c => _stopAndRemoveContainerCommand.ExecuteAsync(c.Id))
+            containerWithSameTag.Select(c => _stopAndRemoveContainerCommand.ExecuteAsync(c.Id, ct))
         );
 
         if (overwrite)
@@ -106,8 +107,8 @@ public class CommitOrchestrator : ICommitOrchestrator
                     "Overwrite not supported when committing untagged container"
                 );
             _events.OnNext(new StatusEvent("Launching new image"));
-            var id = await _createContainerCommand.ExecuteAsync(container, tagPrefix, newTag);
-            await _runContainerCommand.ExecuteAsync(id);
+            var id = await _createContainerCommand.ExecuteAsync(container, tagPrefix, newTag, ct);
+            await _runContainerCommand.ExecuteAsync(id, ct);
         }
         else if (@switch)
         {
@@ -118,11 +119,11 @@ public class CommitOrchestrator : ICommitOrchestrator
             _events.OnNext(
                 new StatusEvent($"Stopping running container '{container.ContainerName}'")
             );
-            await _stopContainerCommand.ExecuteAsync(container.Id);
+            await _stopContainerCommand.ExecuteAsync(container.Id, ct);
 
             _events.OnNext(new StatusEvent("Launching new image"));
-            var id = await _createContainerCommand.ExecuteAsync(container, tagPrefix, newTag);
-            await _runContainerCommand.ExecuteAsync(id);
+            var id = await _createContainerCommand.ExecuteAsync(container, tagPrefix, newTag, ct);
+            await _runContainerCommand.ExecuteAsync(id, ct);
         }
 
         return new CommitResult(imageName, newTag);
@@ -130,15 +131,20 @@ public class CommitOrchestrator : ICommitOrchestrator
 
     private async Task<(string imageName, string tagPrefix, string newTag)> GetNewTagAsync(
         Container container,
-        string tag
+        string tag,
+        CancellationToken ct
     )
     {
-        var image = await _getImageQuery.QueryAsync(container.ImageIdentifier, container.ImageTag);
+        var image = await _getImageQuery.QueryAsync(
+            container.ImageIdentifier,
+            container.ImageTag,
+            ct
+        );
         string imageName;
         string? baseTag = null;
         if (image == null)
         {
-            var digests = await _getDigestsByIdQuery.QueryAsync(container.ImageIdentifier);
+            var digests = await _getDigestsByIdQuery.QueryAsync(container.ImageIdentifier, ct);
             var digest = digests?.SingleOrDefault();
             if (digest == null || !DigestHelper.TryGetImageNameAndId(digest, out var nameAndId))
                 throw new InvalidOperationException(

--- a/src/port.Core/Orchestrators/CommitOrchestrator.cs
+++ b/src/port.Core/Orchestrators/CommitOrchestrator.cs
@@ -46,7 +46,7 @@ public class CommitOrchestrator : ICommitOrchestrator
         string tag,
         bool overwrite,
         bool @switch,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         _events.OnNext(new StatusEvent("Getting running containers"));

--- a/src/port.Core/Orchestrators/CommitOrchestrator.cs
+++ b/src/port.Core/Orchestrators/CommitOrchestrator.cs
@@ -46,11 +46,11 @@ public class CommitOrchestrator : ICommitOrchestrator
         string tag,
         bool overwrite,
         bool @switch,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         _events.OnNext(new StatusEvent("Getting running containers"));
-        var containers = await _getRunningContainersQuery.QueryAsync().ToListAsync(ct);
+        var containers = await _getRunningContainersQuery.QueryAsync().ToListAsync(cancellationToken);
         var container =
             containers.SingleOrDefault(c => c.ContainerName == containerName)
             ?? throw new InvalidOperationException(
@@ -74,7 +74,7 @@ public class CommitOrchestrator : ICommitOrchestrator
         }
         else
         {
-            (imageName, tagPrefix, newTag) = await GetNewTagAsync(container, tag, ct);
+            (imageName, tagPrefix, newTag) = await GetNewTagAsync(container, tag, cancellationToken);
         }
 
         _events.OnNext(
@@ -82,7 +82,7 @@ public class CommitOrchestrator : ICommitOrchestrator
         );
         var containerWithSameTag = await _getContainersQuery
             .QueryByContainerIdentifierAndTagAsync(container.ContainerIdentifier, newTag)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         _events.OnNext(
             new StatusEvent($"Creating image from running container '{container.ContainerName}'")
@@ -92,12 +92,12 @@ public class CommitOrchestrator : ICommitOrchestrator
             imageName,
             tagPrefix,
             newTag,
-            ct
+            cancellationToken
         );
 
         _events.OnNext(new StatusEvent($"Removing containers named '{container.ContainerName}'"));
         await Task.WhenAll(
-            containerWithSameTag.Select(c => _stopAndRemoveContainerCommand.ExecuteAsync(c.Id, ct))
+            containerWithSameTag.Select(c => _stopAndRemoveContainerCommand.ExecuteAsync(c.Id, cancellationToken))
         );
 
         if (overwrite)
@@ -107,8 +107,8 @@ public class CommitOrchestrator : ICommitOrchestrator
                     "Overwrite not supported when committing untagged container"
                 );
             _events.OnNext(new StatusEvent("Launching new image"));
-            var id = await _createContainerCommand.ExecuteAsync(container, tagPrefix, newTag, ct);
-            await _runContainerCommand.ExecuteAsync(id, ct);
+            var id = await _createContainerCommand.ExecuteAsync(container, tagPrefix, newTag, cancellationToken);
+            await _runContainerCommand.ExecuteAsync(id, cancellationToken);
         }
         else if (@switch)
         {
@@ -119,11 +119,11 @@ public class CommitOrchestrator : ICommitOrchestrator
             _events.OnNext(
                 new StatusEvent($"Stopping running container '{container.ContainerName}'")
             );
-            await _stopContainerCommand.ExecuteAsync(container.Id, ct);
+            await _stopContainerCommand.ExecuteAsync(container.Id, cancellationToken);
 
             _events.OnNext(new StatusEvent("Launching new image"));
-            var id = await _createContainerCommand.ExecuteAsync(container, tagPrefix, newTag, ct);
-            await _runContainerCommand.ExecuteAsync(id, ct);
+            var id = await _createContainerCommand.ExecuteAsync(container, tagPrefix, newTag, cancellationToken);
+            await _runContainerCommand.ExecuteAsync(id, cancellationToken);
         }
 
         return new CommitResult(imageName, newTag);
@@ -132,19 +132,19 @@ public class CommitOrchestrator : ICommitOrchestrator
     private async Task<(string imageName, string tagPrefix, string newTag)> GetNewTagAsync(
         Container container,
         string tag,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         var image = await _getImageQuery.QueryAsync(
             container.ImageIdentifier,
             container.ImageTag,
-            ct
+            cancellationToken
         );
         string imageName;
         string? baseTag = null;
         if (image == null)
         {
-            var digests = await _getDigestsByIdQuery.QueryAsync(container.ImageIdentifier, ct);
+            var digests = await _getDigestsByIdQuery.QueryAsync(container.ImageIdentifier, cancellationToken);
             var digest = digests?.SingleOrDefault();
             if (digest == null || !DigestHelper.TryGetImageNameAndId(digest, out var nameAndId))
                 throw new InvalidOperationException(

--- a/src/port.Core/Orchestrators/ICommitOrchestrator.cs
+++ b/src/port.Core/Orchestrators/ICommitOrchestrator.cs
@@ -7,6 +7,6 @@ public interface ICommitOrchestrator : IOrchestrator
         string tag,
         bool overwrite,
         bool @switch,
-        CancellationToken ct = default
+        CancellationToken ct
     );
 }

--- a/src/port.Core/Orchestrators/ICommitOrchestrator.cs
+++ b/src/port.Core/Orchestrators/ICommitOrchestrator.cs
@@ -7,6 +7,6 @@ public interface ICommitOrchestrator : IOrchestrator
         string tag,
         bool overwrite,
         bool @switch,
-        CancellationToken ct
+        CancellationToken cancellationToken
     );
 }

--- a/src/port.Core/Orchestrators/IListOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IListOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IListOrchestrator : IOrchestrator
 {
-    Task<ListResult> ExecuteAsync(string? identifier, CancellationToken ct);
+    Task<ListResult> ExecuteAsync(string? identifier, CancellationToken cancellationToken);
 }

--- a/src/port.Core/Orchestrators/IListOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IListOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IListOrchestrator : IOrchestrator
 {
-    Task<ListResult> ExecuteAsync(string? identifier, CancellationToken ct = default);
+    Task<ListResult> ExecuteAsync(string? identifier, CancellationToken ct);
 }

--- a/src/port.Core/Orchestrators/IPruneOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IPruneOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IPruneOrchestrator : IOrchestrator
 {
-    Task<PruneResult> ExecuteAsync(string? identifier, CancellationToken ct);
+    Task<PruneResult> ExecuteAsync(string? identifier, CancellationToken cancellationToken);
 }

--- a/src/port.Core/Orchestrators/IPruneOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IPruneOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IPruneOrchestrator : IOrchestrator
 {
-    Task<PruneResult> ExecuteAsync(string? identifier, CancellationToken ct = default);
+    Task<PruneResult> ExecuteAsync(string? identifier, CancellationToken ct);
 }

--- a/src/port.Core/Orchestrators/IPullOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IPullOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IPullOrchestrator : IOrchestrator
 {
-    Task<PullResult> ExecuteAsync(string identifier, string? tag, CancellationToken ct = default);
+    Task<PullResult> ExecuteAsync(string identifier, string? tag, CancellationToken ct);
 }

--- a/src/port.Core/Orchestrators/IPullOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IPullOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IPullOrchestrator : IOrchestrator
 {
-    Task<PullResult> ExecuteAsync(string identifier, string? tag, CancellationToken ct);
+    Task<PullResult> ExecuteAsync(string identifier, string? tag, CancellationToken cancellationToken);
 }

--- a/src/port.Core/Orchestrators/IRemoveOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IRemoveOrchestrator.cs
@@ -6,6 +6,6 @@ public interface IRemoveOrchestrator : IOrchestrator
         string identifier,
         string? tag,
         bool recursive,
-        CancellationToken ct = default
+        CancellationToken ct
     );
 }

--- a/src/port.Core/Orchestrators/IRemoveOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IRemoveOrchestrator.cs
@@ -6,6 +6,6 @@ public interface IRemoveOrchestrator : IOrchestrator
         string identifier,
         string? tag,
         bool recursive,
-        CancellationToken ct
+        CancellationToken cancellationToken
     );
 }

--- a/src/port.Core/Orchestrators/IResetOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IResetOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IResetOrchestrator : IOrchestrator
 {
-    Task<ResetResult> ExecuteAsync(string containerName, CancellationToken ct);
+    Task<ResetResult> ExecuteAsync(string containerName, CancellationToken cancellationToken);
 }

--- a/src/port.Core/Orchestrators/IResetOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IResetOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IResetOrchestrator : IOrchestrator
 {
-    Task<ResetResult> ExecuteAsync(string containerName, CancellationToken ct = default);
+    Task<ResetResult> ExecuteAsync(string containerName, CancellationToken ct);
 }

--- a/src/port.Core/Orchestrators/IRunOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IRunOrchestrator.cs
@@ -6,6 +6,6 @@ public interface IRunOrchestrator : IOrchestrator
         string identifier,
         string tag,
         bool reset,
-        CancellationToken ct
+        CancellationToken cancellationToken
     );
 }

--- a/src/port.Core/Orchestrators/IRunOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IRunOrchestrator.cs
@@ -6,6 +6,6 @@ public interface IRunOrchestrator : IOrchestrator
         string identifier,
         string tag,
         bool reset,
-        CancellationToken ct = default
+        CancellationToken ct
     );
 }

--- a/src/port.Core/Orchestrators/IStopOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IStopOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IStopOrchestrator : IOrchestrator
 {
-    Task<StopResult> ExecuteAsync(string containerName, CancellationToken ct);
+    Task<StopResult> ExecuteAsync(string containerName, CancellationToken cancellationToken);
 }

--- a/src/port.Core/Orchestrators/IStopOrchestrator.cs
+++ b/src/port.Core/Orchestrators/IStopOrchestrator.cs
@@ -2,5 +2,5 @@ namespace port.Orchestrators;
 
 public interface IStopOrchestrator : IOrchestrator
 {
-    Task<StopResult> ExecuteAsync(string containerName, CancellationToken ct = default);
+    Task<StopResult> ExecuteAsync(string containerName, CancellationToken ct);
 }

--- a/src/port.Core/Orchestrators/ListOrchestrator.cs
+++ b/src/port.Core/Orchestrators/ListOrchestrator.cs
@@ -14,7 +14,7 @@ public class ListOrchestrator : IListOrchestrator
 
     public IObservable<OrchestrationEvent> Events => _events;
 
-    public async Task<ListResult> ExecuteAsync(string? identifier, CancellationToken ct = default)
+    public async Task<ListResult> ExecuteAsync(string? identifier, CancellationToken ct)
     {
         _events.OnNext(new StatusEvent("Loading images"));
         var groups = (await _allImagesQuery.QueryAsync().ToListAsync(ct))

--- a/src/port.Core/Orchestrators/ListOrchestrator.cs
+++ b/src/port.Core/Orchestrators/ListOrchestrator.cs
@@ -14,10 +14,10 @@ public class ListOrchestrator : IListOrchestrator
 
     public IObservable<OrchestrationEvent> Events => _events;
 
-    public async Task<ListResult> ExecuteAsync(string? identifier, CancellationToken ct)
+    public async Task<ListResult> ExecuteAsync(string? identifier, CancellationToken cancellationToken)
     {
         _events.OnNext(new StatusEvent("Loading images"));
-        var groups = (await _allImagesQuery.QueryAsync().ToListAsync(ct))
+        var groups = (await _allImagesQuery.QueryAsync().ToListAsync(cancellationToken))
             .Where(g => identifier == null || g.Identifier == identifier)
             .OrderBy(g => g.Identifier)
             .ToList();

--- a/src/port.Core/Orchestrators/PruneOrchestrator.cs
+++ b/src/port.Core/Orchestrators/PruneOrchestrator.cs
@@ -21,7 +21,7 @@ public class PruneOrchestrator : IPruneOrchestrator
 
     public async Task<PruneResult> ExecuteAsync(
         string? identifier,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         var imageGroups = await _allImagesQuery

--- a/src/port.Core/Orchestrators/PruneOrchestrator.cs
+++ b/src/port.Core/Orchestrators/PruneOrchestrator.cs
@@ -21,13 +21,13 @@ public class PruneOrchestrator : IPruneOrchestrator
 
     public async Task<PruneResult> ExecuteAsync(
         string? identifier,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         var imageGroups = await _allImagesQuery
             .QueryAsync()
             .Where(g => identifier == null || g.Identifier == identifier)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         var pruneableImages = imageGroups
             .SelectMany(g => g.Images)
@@ -41,7 +41,7 @@ public class PruneOrchestrator : IPruneOrchestrator
         var removals = await _removeImagesCommand.ExecuteAsync(
             pruneableImages.Select(i => i.Id!).ToList(),
             _events,
-            ct
+            cancellationToken
         );
         return new PruneResult(removals);
     }

--- a/src/port.Core/Orchestrators/PullOrchestrator.cs
+++ b/src/port.Core/Orchestrators/PullOrchestrator.cs
@@ -38,7 +38,7 @@ public class PullOrchestrator : IPullOrchestrator
             error => _events.OnError(error)
         );
 
-        await _createImageCommand.ExecuteAsync(imageName, tag);
+        await _createImageCommand.ExecuteAsync(imageName, tag, ct);
         return new PullResult(imageName, tag);
     }
 

--- a/src/port.Core/Orchestrators/PullOrchestrator.cs
+++ b/src/port.Core/Orchestrators/PullOrchestrator.cs
@@ -20,7 +20,7 @@ public class PullOrchestrator : IPullOrchestrator
     public async Task<PullResult> ExecuteAsync(
         string identifier,
         string? tag,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         var imageConfig =
@@ -38,7 +38,7 @@ public class PullOrchestrator : IPullOrchestrator
             error => _events.OnError(error)
         );
 
-        await _createImageCommand.ExecuteAsync(imageName, tag, ct);
+        await _createImageCommand.ExecuteAsync(imageName, tag, cancellationToken);
         return new PullResult(imageName, tag);
     }
 

--- a/src/port.Core/Orchestrators/PullOrchestrator.cs
+++ b/src/port.Core/Orchestrators/PullOrchestrator.cs
@@ -20,7 +20,7 @@ public class PullOrchestrator : IPullOrchestrator
     public async Task<PullResult> ExecuteAsync(
         string identifier,
         string? tag,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         var imageConfig =

--- a/src/port.Core/Orchestrators/RemoveOrchestrator.cs
+++ b/src/port.Core/Orchestrators/RemoveOrchestrator.cs
@@ -29,7 +29,7 @@ public class RemoveOrchestrator : IRemoveOrchestrator
         string identifier,
         string? tag,
         bool recursive,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         _events.OnNext(new StatusEvent($"Removing {ImageNameHelper.BuildImageName(identifier, tag)}"));
@@ -43,30 +43,30 @@ public class RemoveOrchestrator : IRemoveOrchestrator
                 await _getImageIdQuery.QueryAsync(
                     imageName,
                     $"{TagPrefixHelper.GetTagPrefix(identifier)}{tag}",
-                    ct
+                    cancellationToken
                 )
             );
         }
 
-        initialImageIds.AddRange(await _getImageIdQuery.QueryAsync(imageName, tag, ct));
+        initialImageIds.AddRange(await _getImageIdQuery.QueryAsync(imageName, tag, cancellationToken));
 
         var imageIds = recursive
-            ? await ResolveRecursiveAsync(initialImageIds, ct)
+            ? await ResolveRecursiveAsync(initialImageIds, cancellationToken)
             : initialImageIds.ToList();
 
         if (imageIds.Count == 0)
             throw new InvalidOperationException("No images to remove found");
 
-        var removals = await _removeImagesCommand.ExecuteAsync(imageIds, _events, ct);
+        var removals = await _removeImagesCommand.ExecuteAsync(imageIds, _events, cancellationToken);
         return new RemoveResult(removals);
     }
 
     private async Task<List<string>> ResolveRecursiveAsync(
         List<string> initialImageIds,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
-        var images = await _allImagesQuery.QueryAllImagesWithParentAsync().ToListAsync(ct);
+        var images = await _allImagesQuery.QueryAllImagesWithParentAsync().ToListAsync(cancellationToken);
 
         var imageIds = new List<string>();
         var imageIdsToAnalyze = initialImageIds.ToHashSet();

--- a/src/port.Core/Orchestrators/RemoveOrchestrator.cs
+++ b/src/port.Core/Orchestrators/RemoveOrchestrator.cs
@@ -29,7 +29,7 @@ public class RemoveOrchestrator : IRemoveOrchestrator
         string identifier,
         string? tag,
         bool recursive,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         _events.OnNext(new StatusEvent($"Removing {ImageNameHelper.BuildImageName(identifier, tag)}"));

--- a/src/port.Core/Orchestrators/RemoveOrchestrator.cs
+++ b/src/port.Core/Orchestrators/RemoveOrchestrator.cs
@@ -42,12 +42,13 @@ public class RemoveOrchestrator : IRemoveOrchestrator
             initialImageIds.AddRange(
                 await _getImageIdQuery.QueryAsync(
                     imageName,
-                    $"{TagPrefixHelper.GetTagPrefix(identifier)}{tag}"
+                    $"{TagPrefixHelper.GetTagPrefix(identifier)}{tag}",
+                    ct
                 )
             );
         }
 
-        initialImageIds.AddRange(await _getImageIdQuery.QueryAsync(imageName, tag));
+        initialImageIds.AddRange(await _getImageIdQuery.QueryAsync(imageName, tag, ct));
 
         var imageIds = recursive
             ? await ResolveRecursiveAsync(initialImageIds, ct)

--- a/src/port.Core/Orchestrators/ResetOrchestrator.cs
+++ b/src/port.Core/Orchestrators/ResetOrchestrator.cs
@@ -27,11 +27,11 @@ public class ResetOrchestrator : IResetOrchestrator
 
     public async Task<ResetResult> ExecuteAsync(
         string containerName,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         _events.OnNext(new StatusEvent("Getting running containers"));
-        var containers = await _getRunningContainersQuery.QueryAsync().ToListAsync(ct);
+        var containers = await _getRunningContainersQuery.QueryAsync().ToListAsync(cancellationToken);
         var container =
             containers.SingleOrDefault(c => c.ContainerName == containerName)
             ?? throw new InvalidOperationException(
@@ -39,9 +39,9 @@ public class ResetOrchestrator : IResetOrchestrator
             );
 
         _events.OnNext(new StatusEvent($"Resetting container '{container.ContainerName}'"));
-        await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, ct);
-        var id = await _createContainerCommand.ExecuteAsync(container, ct);
-        await _runContainerCommand.ExecuteAsync(id, ct);
+        await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, cancellationToken);
+        var id = await _createContainerCommand.ExecuteAsync(container, cancellationToken);
+        await _runContainerCommand.ExecuteAsync(id, cancellationToken);
         return new ResetResult(id, container.ContainerName);
     }
 }

--- a/src/port.Core/Orchestrators/ResetOrchestrator.cs
+++ b/src/port.Core/Orchestrators/ResetOrchestrator.cs
@@ -39,9 +39,9 @@ public class ResetOrchestrator : IResetOrchestrator
             );
 
         _events.OnNext(new StatusEvent($"Resetting container '{container.ContainerName}'"));
-        await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id);
-        var id = await _createContainerCommand.ExecuteAsync(container);
-        await _runContainerCommand.ExecuteAsync(id);
+        await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, ct);
+        var id = await _createContainerCommand.ExecuteAsync(container, ct);
+        await _runContainerCommand.ExecuteAsync(id, ct);
         return new ResetResult(id, container.ContainerName);
     }
 }

--- a/src/port.Core/Orchestrators/ResetOrchestrator.cs
+++ b/src/port.Core/Orchestrators/ResetOrchestrator.cs
@@ -27,7 +27,7 @@ public class ResetOrchestrator : IResetOrchestrator
 
     public async Task<ResetResult> ExecuteAsync(
         string containerName,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         _events.OnNext(new StatusEvent("Getting running containers"));

--- a/src/port.Core/Orchestrators/RunOrchestrator.cs
+++ b/src/port.Core/Orchestrators/RunOrchestrator.cs
@@ -46,7 +46,7 @@ public class RunOrchestrator : IRunOrchestrator
         string identifier,
         string tag,
         bool reset,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         var imageConfig =
@@ -56,13 +56,13 @@ public class RunOrchestrator : IRunOrchestrator
                 nameof(identifier)
             );
 
-        await TerminateOtherContainersAsync(imageConfig, ct);
-        return await LaunchImageAsync(identifier, tag, reset, imageConfig, ct);
+        await TerminateOtherContainersAsync(imageConfig, cancellationToken);
+        return await LaunchImageAsync(identifier, tag, reset, imageConfig, cancellationToken);
     }
 
     private async Task TerminateOtherContainersAsync(
         port.Config.Config.ImageConfig imageConfig,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         var hostPorts = imageConfig.Ports.Select(e => e.Split(PortSeparator)[0]).ToList();
@@ -72,8 +72,8 @@ public class RunOrchestrator : IRunOrchestrator
             )
         );
         var containers = GetRunningContainersUsingHostPortsAsync(hostPorts);
-        await foreach (var container in containers.WithCancellation(ct))
-            await _stopContainerCommand.ExecuteAsync(container.Id, ct);
+        await foreach (var container in containers.WithCancellation(cancellationToken))
+            await _stopContainerCommand.ExecuteAsync(container.Id, cancellationToken);
     }
 
     private IAsyncEnumerable<Container> GetRunningContainersUsingHostPortsAsync(
@@ -100,7 +100,7 @@ public class RunOrchestrator : IRunOrchestrator
         string tag,
         bool resetContainer,
         port.Config.Config.ImageConfig imageConfig,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         var constructedImageName = ImageNameHelper.BuildImageName(identifier, tag);
@@ -108,14 +108,14 @@ public class RunOrchestrator : IRunOrchestrator
         var containerName = ContainerNameHelper.BuildContainerName(identifier, tag);
 
         _events.OnNext(new StatusEvent($"Query existing image: {constructedImageName}"));
-        var existingImage = await QueryExistingAsync(imageConfig, imageName, identifier, tag, ct);
+        var existingImage = await QueryExistingAsync(imageConfig, imageName, identifier, tag, cancellationToken);
         var resolvedTag = existingImage?.Tag ?? tag;
 
         if (existingImage is null)
         {
-            await PullImageAsync(imageName, tag, ct);
+            await PullImageAsync(imageName, tag, cancellationToken);
             _events.OnNext(new StatusEvent($"Re-query existing image: {constructedImageName}"));
-            existingImage = await _getImageQuery.QueryAsync(imageName, tag, ct);
+            existingImage = await _getImageQuery.QueryAsync(imageName, tag, cancellationToken);
             resolvedTag = existingImage?.Tag ?? tag;
         }
 
@@ -124,7 +124,7 @@ public class RunOrchestrator : IRunOrchestrator
         _events.OnNext(new StatusEvent($"Launching {constructedImageName}"));
         var containers = await _getContainersQuery
             .QueryByContainerNameAsync(containerName)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
         var ports = imageConfig.Ports;
         var environment = imageConfig.Environment;
 
@@ -135,7 +135,7 @@ public class RunOrchestrator : IRunOrchestrator
             var imageChanged = existingImage?.Id != null && container.ImageId != existingImage.Id;
             if (resetContainer)
             {
-                await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, ct);
+                await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, cancellationToken);
                 runningId = await _createContainerCommand.ExecuteAsync(
                     identifier,
                     imageName,
@@ -143,18 +143,18 @@ public class RunOrchestrator : IRunOrchestrator
                     resolvedTag,
                     ports,
                     environment,
-                    ct
+                    cancellationToken
                 );
-                await _runContainerCommand.ExecuteAsync(runningId, ct);
+                await _runContainerCommand.ExecuteAsync(runningId, cancellationToken);
             }
             else if (imageChanged)
             {
-                await _stopContainerCommand.ExecuteAsync(container.Id, ct);
+                await _stopContainerCommand.ExecuteAsync(container.Id, cancellationToken);
                 var renamedContainerName = ContainerNameHelper.BuildContainerName(
                     identifier,
                     container.ImageId
                 );
-                await _renameContainerCommand.ExecuteAsync(container.Id, renamedContainerName, ct);
+                await _renameContainerCommand.ExecuteAsync(container.Id, renamedContainerName, cancellationToken);
                 runningId = await _createContainerCommand.ExecuteAsync(
                     identifier,
                     imageName,
@@ -162,14 +162,14 @@ public class RunOrchestrator : IRunOrchestrator
                     resolvedTag,
                     ports,
                     environment,
-                    ct
+                    cancellationToken
                 );
-                await _runContainerCommand.ExecuteAsync(runningId, ct);
+                await _runContainerCommand.ExecuteAsync(runningId, cancellationToken);
             }
             else
             {
                 runningId = container.Id;
-                await _runContainerCommand.ExecuteAsync(runningId, ct);
+                await _runContainerCommand.ExecuteAsync(runningId, cancellationToken);
             }
         }
         else
@@ -181,9 +181,9 @@ public class RunOrchestrator : IRunOrchestrator
                 resolvedTag,
                 ports,
                 environment,
-                ct
+                cancellationToken
             );
-            await _runContainerCommand.ExecuteAsync(runningId, ct);
+            await _runContainerCommand.ExecuteAsync(runningId, cancellationToken);
         }
 
         return new RunResult(identifier, tag, runningId, containerName);
@@ -194,25 +194,25 @@ public class RunOrchestrator : IRunOrchestrator
         string imageName,
         string identifier,
         string tag,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         if (imageConfig.ImageTags.Contains(tag))
-            return await _getImageQuery.QueryAsync(imageName, tag, ct);
-        var existing = await _getImageQuery.QueryAsync(imageName, tag, ct);
+            return await _getImageQuery.QueryAsync(imageName, tag, cancellationToken);
+        var existing = await _getImageQuery.QueryAsync(imageName, tag, cancellationToken);
         if (existing is not null)
             return existing;
         var prefixed = $"{TagPrefixHelper.GetTagPrefix(identifier)}{tag}";
-        return await _getImageQuery.QueryAsync(imageName, prefixed, ct);
+        return await _getImageQuery.QueryAsync(imageName, prefixed, cancellationToken);
     }
 
-    private async Task PullImageAsync(string imageName, string? tag, CancellationToken ct)
+    private async Task PullImageAsync(string imageName, string? tag, CancellationToken cancellationToken)
     {
         using var subscription = _createImageCommand.ProgressObservable.Subscribe(
             progress => _events.OnNext(ToLayerEvent(progress, tag)),
             error => _events.OnError(error)
         );
-        await _createImageCommand.ExecuteAsync(imageName, tag, ct);
+        await _createImageCommand.ExecuteAsync(imageName, tag, cancellationToken);
     }
 
     private static LayerProgressEvent ToLayerEvent(Progress progress, string? requestedTag)

--- a/src/port.Core/Orchestrators/RunOrchestrator.cs
+++ b/src/port.Core/Orchestrators/RunOrchestrator.cs
@@ -73,7 +73,7 @@ public class RunOrchestrator : IRunOrchestrator
         );
         var containers = GetRunningContainersUsingHostPortsAsync(hostPorts);
         await foreach (var container in containers.WithCancellation(ct))
-            await _stopContainerCommand.ExecuteAsync(container.Id);
+            await _stopContainerCommand.ExecuteAsync(container.Id, ct);
     }
 
     private IAsyncEnumerable<Container> GetRunningContainersUsingHostPortsAsync(
@@ -108,14 +108,14 @@ public class RunOrchestrator : IRunOrchestrator
         var containerName = ContainerNameHelper.BuildContainerName(identifier, tag);
 
         _events.OnNext(new StatusEvent($"Query existing image: {constructedImageName}"));
-        var existingImage = await QueryExistingAsync(imageConfig, imageName, identifier, tag);
+        var existingImage = await QueryExistingAsync(imageConfig, imageName, identifier, tag, ct);
         var resolvedTag = existingImage?.Tag ?? tag;
 
         if (existingImage is null)
         {
-            await PullImageAsync(imageName, tag);
+            await PullImageAsync(imageName, tag, ct);
             _events.OnNext(new StatusEvent($"Re-query existing image: {constructedImageName}"));
-            existingImage = await _getImageQuery.QueryAsync(imageName, tag);
+            existingImage = await _getImageQuery.QueryAsync(imageName, tag, ct);
             resolvedTag = existingImage?.Tag ?? tag;
         }
 
@@ -135,39 +135,41 @@ public class RunOrchestrator : IRunOrchestrator
             var imageChanged = existingImage?.Id != null && container.ImageId != existingImage.Id;
             if (resetContainer)
             {
-                await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id);
+                await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, ct);
                 runningId = await _createContainerCommand.ExecuteAsync(
                     identifier,
                     imageName,
                     tagPrefix,
                     resolvedTag,
                     ports,
-                    environment
+                    environment,
+                    ct
                 );
-                await _runContainerCommand.ExecuteAsync(runningId);
+                await _runContainerCommand.ExecuteAsync(runningId, ct);
             }
             else if (imageChanged)
             {
-                await _stopContainerCommand.ExecuteAsync(container.Id);
+                await _stopContainerCommand.ExecuteAsync(container.Id, ct);
                 var renamedContainerName = ContainerNameHelper.BuildContainerName(
                     identifier,
                     container.ImageId
                 );
-                await _renameContainerCommand.ExecuteAsync(container.Id, renamedContainerName);
+                await _renameContainerCommand.ExecuteAsync(container.Id, renamedContainerName, ct);
                 runningId = await _createContainerCommand.ExecuteAsync(
                     identifier,
                     imageName,
                     tagPrefix,
                     resolvedTag,
                     ports,
-                    environment
+                    environment,
+                    ct
                 );
-                await _runContainerCommand.ExecuteAsync(runningId);
+                await _runContainerCommand.ExecuteAsync(runningId, ct);
             }
             else
             {
                 runningId = container.Id;
-                await _runContainerCommand.ExecuteAsync(runningId);
+                await _runContainerCommand.ExecuteAsync(runningId, ct);
             }
         }
         else
@@ -178,9 +180,10 @@ public class RunOrchestrator : IRunOrchestrator
                 tagPrefix,
                 resolvedTag,
                 ports,
-                environment
+                environment,
+                ct
             );
-            await _runContainerCommand.ExecuteAsync(runningId);
+            await _runContainerCommand.ExecuteAsync(runningId, ct);
         }
 
         return new RunResult(identifier, tag, runningId, containerName);
@@ -190,25 +193,26 @@ public class RunOrchestrator : IRunOrchestrator
         port.Config.Config.ImageConfig imageConfig,
         string imageName,
         string identifier,
-        string tag
+        string tag,
+        CancellationToken ct
     )
     {
         if (imageConfig.ImageTags.Contains(tag))
-            return await _getImageQuery.QueryAsync(imageName, tag);
-        var existing = await _getImageQuery.QueryAsync(imageName, tag);
+            return await _getImageQuery.QueryAsync(imageName, tag, ct);
+        var existing = await _getImageQuery.QueryAsync(imageName, tag, ct);
         if (existing is not null)
             return existing;
         var prefixed = $"{TagPrefixHelper.GetTagPrefix(identifier)}{tag}";
-        return await _getImageQuery.QueryAsync(imageName, prefixed);
+        return await _getImageQuery.QueryAsync(imageName, prefixed, ct);
     }
 
-    private async Task PullImageAsync(string imageName, string? tag)
+    private async Task PullImageAsync(string imageName, string? tag, CancellationToken ct)
     {
         using var subscription = _createImageCommand.ProgressObservable.Subscribe(
             progress => _events.OnNext(ToLayerEvent(progress, tag)),
             error => _events.OnError(error)
         );
-        await _createImageCommand.ExecuteAsync(imageName, tag);
+        await _createImageCommand.ExecuteAsync(imageName, tag, ct);
     }
 
     private static LayerProgressEvent ToLayerEvent(Progress progress, string? requestedTag)

--- a/src/port.Core/Orchestrators/RunOrchestrator.cs
+++ b/src/port.Core/Orchestrators/RunOrchestrator.cs
@@ -46,7 +46,7 @@ public class RunOrchestrator : IRunOrchestrator
         string identifier,
         string tag,
         bool reset,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         var imageConfig =

--- a/src/port.Core/Orchestrators/StopOrchestrator.cs
+++ b/src/port.Core/Orchestrators/StopOrchestrator.cs
@@ -21,11 +21,11 @@ public class StopOrchestrator : IStopOrchestrator
 
     public async Task<StopResult> ExecuteAsync(
         string containerName,
-        CancellationToken ct
+        CancellationToken cancellationToken
     )
     {
         _events.OnNext(new StatusEvent("Getting running containers"));
-        var containers = await _getRunningContainersQuery.QueryAsync().ToListAsync(ct);
+        var containers = await _getRunningContainersQuery.QueryAsync().ToListAsync(cancellationToken);
         var container =
             containers.SingleOrDefault(c => c.ContainerName == containerName)
             ?? throw new InvalidOperationException(
@@ -33,7 +33,7 @@ public class StopOrchestrator : IStopOrchestrator
             );
 
         _events.OnNext(new StatusEvent($"Stopping container '{container.ContainerName}'"));
-        await _stopContainerCommand.ExecuteAsync(container.Id, ct);
+        await _stopContainerCommand.ExecuteAsync(container.Id, cancellationToken);
         return new StopResult(container.Id, container.ContainerName);
     }
 }

--- a/src/port.Core/Orchestrators/StopOrchestrator.cs
+++ b/src/port.Core/Orchestrators/StopOrchestrator.cs
@@ -33,7 +33,7 @@ public class StopOrchestrator : IStopOrchestrator
             );
 
         _events.OnNext(new StatusEvent($"Stopping container '{container.ContainerName}'"));
-        await _stopContainerCommand.ExecuteAsync(container.Id);
+        await _stopContainerCommand.ExecuteAsync(container.Id, ct);
         return new StopResult(container.Id, container.ContainerName);
     }
 }

--- a/src/port.Core/Orchestrators/StopOrchestrator.cs
+++ b/src/port.Core/Orchestrators/StopOrchestrator.cs
@@ -21,7 +21,7 @@ public class StopOrchestrator : IStopOrchestrator
 
     public async Task<StopResult> ExecuteAsync(
         string containerName,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         _events.OnNext(new StatusEvent("Getting running containers"));

--- a/src/port.Core/RemoveImageCommand.cs
+++ b/src/port.Core/RemoveImageCommand.cs
@@ -13,7 +13,7 @@ public class RemoveImageCommand : IRemoveImageCommand
         _dockerClient = dockerClient;
     }
 
-    public Task ExecuteAsync(string imageName, string? tag)
+    public Task ExecuteAsync(string imageName, string? tag, CancellationToken cancellationToken)
     {
         if (tag == null)
         {
@@ -22,15 +22,20 @@ public class RemoveImageCommand : IRemoveImageCommand
 
         return _dockerClient.Images.DeleteImageAsync(
             ImageNameHelper.BuildImageName(imageName, tag),
-            new ImageDeleteParameters()
+            new ImageDeleteParameters(),
+            cancellationToken
         );
     }
 
-    public async Task<ImageRemovalResult> ExecuteAsync(string id)
+    public async Task<ImageRemovalResult> ExecuteAsync(string id, CancellationToken cancellationToken)
     {
         try
         {
-            await _dockerClient.Images.DeleteImageAsync(id, new ImageDeleteParameters());
+            await _dockerClient.Images.DeleteImageAsync(
+                id,
+                new ImageDeleteParameters(),
+                cancellationToken
+            );
             return new ImageRemovalResult(id, true);
         }
         catch (DockerApiException e) when (e.StatusCode == HttpStatusCode.Conflict)

--- a/src/port.Core/RemoveImagesCommand.cs
+++ b/src/port.Core/RemoveImagesCommand.cs
@@ -34,11 +34,11 @@ public class RemoveImagesCommand : IRemoveImagesCommand
             foreach (var container in containers)
             {
                 ct.ThrowIfCancellationRequested();
-                await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id);
+                await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, ct);
             }
 
             events?.OnNext(new StatusEvent($"Containers using '{imageId}' removed"));
-            result.Add(await _removeImageCommand.ExecuteAsync(imageId));
+            result.Add(await _removeImageCommand.ExecuteAsync(imageId, ct));
         }
 
         return result;

--- a/src/port.Core/RemoveImagesCommand.cs
+++ b/src/port.Core/RemoveImagesCommand.cs
@@ -22,23 +22,23 @@ public class RemoveImagesCommand : IRemoveImagesCommand
     public async Task<List<ImageRemovalResult>> ExecuteAsync(
         List<string> imageIds,
         IObserver<OrchestrationEvent>? events = null,
-        CancellationToken ct = default
+        CancellationToken cancellationToken = default
     )
     {
         var result = new List<ImageRemovalResult>();
         foreach (var imageId in imageIds)
         {
-            ct.ThrowIfCancellationRequested();
-            var containers = await _getContainersQuery.QueryByImageIdAsync(imageId).ToListAsync(ct);
+            cancellationToken.ThrowIfCancellationRequested();
+            var containers = await _getContainersQuery.QueryByImageIdAsync(imageId).ToListAsync(cancellationToken);
             events?.OnNext(new StatusEvent($"Removing containers using '{imageId}'"));
             foreach (var container in containers)
             {
-                ct.ThrowIfCancellationRequested();
-                await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, ct);
+                cancellationToken.ThrowIfCancellationRequested();
+                await _stopAndRemoveContainerCommand.ExecuteAsync(container.Id, cancellationToken);
             }
 
             events?.OnNext(new StatusEvent($"Containers using '{imageId}' removed"));
-            result.Add(await _removeImageCommand.ExecuteAsync(imageId, ct));
+            result.Add(await _removeImageCommand.ExecuteAsync(imageId, cancellationToken));
         }
 
         return result;

--- a/src/port.Core/RenameContainerCommand.cs
+++ b/src/port.Core/RenameContainerCommand.cs
@@ -12,10 +12,10 @@ public class RenameContainerCommand : IRenameContainerCommand
         _dockerClient = dockerClient;
     }
 
-    public async Task ExecuteAsync(string containerId, string newName) =>
+    public async Task ExecuteAsync(string containerId, string newName, CancellationToken cancellationToken) =>
         await _dockerClient.Containers.RenameContainerAsync(
             containerId,
             new ContainerRenameParameters { NewName = newName },
-            CancellationToken.None
+            cancellationToken
         );
 }

--- a/src/port.Core/RunContainerCommand.cs
+++ b/src/port.Core/RunContainerCommand.cs
@@ -12,16 +12,21 @@ public class RunContainerCommand : IRunContainerCommand
         _dockerClient = dockerClient;
     }
 
-    public Task ExecuteAsync(string id)
+    public Task ExecuteAsync(string id, CancellationToken cancellationToken)
     {
-        return _dockerClient.Containers.StartContainerAsync(id, new ContainerStartParameters());
+        return _dockerClient.Containers.StartContainerAsync(
+            id,
+            new ContainerStartParameters(),
+            cancellationToken
+        );
     }
 
-    public Task ExecuteAsync(Container container)
+    public Task ExecuteAsync(Container container, CancellationToken cancellationToken)
     {
         return _dockerClient.Containers.StartContainerAsync(
             container.Id,
-            new ContainerStartParameters()
+            new ContainerStartParameters(),
+            cancellationToken
         );
     }
 }

--- a/src/port.Core/StopAndRemoveContainerCommand.cs
+++ b/src/port.Core/StopAndRemoveContainerCommand.cs
@@ -17,12 +17,13 @@ public class StopAndRemoveContainerCommand : IStopAndRemoveContainerCommand
         _stopContainerCommand = stopContainerCommand;
     }
 
-    public async Task ExecuteAsync(string containerId)
+    public async Task ExecuteAsync(string containerId, CancellationToken cancellationToken)
     {
-        await _stopContainerCommand.ExecuteAsync(containerId);
+        await _stopContainerCommand.ExecuteAsync(containerId, cancellationToken);
         await _dockerClient.Containers.RemoveContainerAsync(
             containerId,
-            new ContainerRemoveParameters()
+            new ContainerRemoveParameters(),
+            cancellationToken
         );
     }
 }

--- a/src/port.Core/StopContainerCommand.cs
+++ b/src/port.Core/StopContainerCommand.cs
@@ -12,9 +12,10 @@ public class StopContainerCommand : IStopContainerCommand
         _dockerClient = dockerClient;
     }
 
-    public async Task ExecuteAsync(string containerId) =>
+    public async Task ExecuteAsync(string containerId, CancellationToken cancellationToken) =>
         await _dockerClient.Containers.StopContainerAsync(
             containerId,
-            new ContainerStopParameters()
+            new ContainerStopParameters(),
+            cancellationToken
         );
 }

--- a/src/port.Mcp/PortMcpTools.cs
+++ b/src/port.Mcp/PortMcpTools.cs
@@ -17,11 +17,11 @@ public static class PortMcpTools
             string identifier,
         [Description("Image tag to launch (e.g. 'latest')")] string tag,
         [Description("Recreate the container instead of restarting it")] bool reset = false,
-        CancellationToken ct = default
+        CancellationToken cancellationToken = default
     ) =>
         EventCollector.InvokeAsync(
             orchestrator.Events,
-            () => orchestrator.ExecuteAsync(identifier, tag, reset, ct)
+            () => orchestrator.ExecuteAsync(identifier, tag, reset, cancellationToken)
         );
 
     [McpServerTool(Name = "stop")]
@@ -29,11 +29,11 @@ public static class PortMcpTools
     public static Task<McpToolResponse<StopResult>> StopAsync(
         IStopOrchestrator orchestrator,
         [Description("Exact container name as shown by the list tool")] string containerName,
-        CancellationToken ct = default
+        CancellationToken cancellationToken = default
     ) =>
         EventCollector.InvokeAsync(
             orchestrator.Events,
-            () => orchestrator.ExecuteAsync(containerName, ct)
+            () => orchestrator.ExecuteAsync(containerName, cancellationToken)
         );
 
     [McpServerTool(Name = "reset")]
@@ -43,11 +43,11 @@ public static class PortMcpTools
     public static Task<McpToolResponse<ResetResult>> ResetAsync(
         IResetOrchestrator orchestrator,
         [Description("Exact container name to reset")] string containerName,
-        CancellationToken ct = default
+        CancellationToken cancellationToken = default
     ) =>
         EventCollector.InvokeAsync(
             orchestrator.Events,
-            () => orchestrator.ExecuteAsync(containerName, ct)
+            () => orchestrator.ExecuteAsync(containerName, cancellationToken)
         );
 
     [McpServerTool(Name = "commit")]
@@ -60,11 +60,11 @@ public static class PortMcpTools
         [Description("Tag for the new snapshot image")] string tag,
         [Description("Overwrite the container's current tag")] bool overwrite = false,
         [Description("Stop the source container and switch to the new image")] bool @switch = false,
-        CancellationToken ct = default
+        CancellationToken cancellationToken = default
     ) =>
         EventCollector.InvokeAsync(
             orchestrator.Events,
-            () => orchestrator.ExecuteAsync(containerName, tag, overwrite, @switch, ct)
+            () => orchestrator.ExecuteAsync(containerName, tag, overwrite, @switch, cancellationToken)
         );
 
     [McpServerTool(Name = "pull")]
@@ -73,8 +73,8 @@ public static class PortMcpTools
         IPullOrchestrator orchestrator,
         [Description("Image identifier as defined in port config")] string identifier,
         [Description("Optional image tag; pulls the configured tags if omitted")] string? tag = null,
-        CancellationToken ct = default
-    ) => EventCollector.InvokeAsync(() => orchestrator.ExecuteAsync(identifier, tag, ct));
+        CancellationToken cancellationToken = default
+    ) => EventCollector.InvokeAsync(() => orchestrator.ExecuteAsync(identifier, tag, cancellationToken));
 
     [McpServerTool(Name = "remove")]
     [Description(
@@ -85,11 +85,11 @@ public static class PortMcpTools
         [Description("Image identifier as defined in port config")] string identifier,
         [Description("Optional tag; if omitted, removes images for the configured tag")] string? tag = null,
         [Description("Also remove descendant snapshot images")] bool recursive = false,
-        CancellationToken ct = default
+        CancellationToken cancellationToken = default
     ) =>
         EventCollector.InvokeAsync(
             orchestrator.Events,
-            () => orchestrator.ExecuteAsync(identifier, tag, recursive, ct)
+            () => orchestrator.ExecuteAsync(identifier, tag, recursive, cancellationToken)
         );
 
     [McpServerTool(Name = "prune")]
@@ -97,11 +97,11 @@ public static class PortMcpTools
     public static Task<McpToolResponse<PruneResult>> PruneAsync(
         IPruneOrchestrator orchestrator,
         [Description("Optional image identifier to restrict pruning")] string? identifier = null,
-        CancellationToken ct = default
+        CancellationToken cancellationToken = default
     ) =>
         EventCollector.InvokeAsync(
             orchestrator.Events,
-            () => orchestrator.ExecuteAsync(identifier, ct)
+            () => orchestrator.ExecuteAsync(identifier, cancellationToken)
         );
 
     [McpServerTool(Name = "list")]
@@ -111,8 +111,8 @@ public static class PortMcpTools
     public static Task<ListResult> ListAsync(
         IListOrchestrator orchestrator,
         [Description("Optional image identifier to restrict the listing")] string? identifier = null,
-        CancellationToken ct = default
-    ) => EventCollector.InvokeAsync(() => orchestrator.ExecuteAsync(identifier, ct));
+        CancellationToken cancellationToken = default
+    ) => EventCollector.InvokeAsync(() => orchestrator.ExecuteAsync(identifier, cancellationToken));
 
     [McpServerTool(Name = "config")]
     [Description("Return the absolute path to port's config file.")]

--- a/src/port/McpCliCommand.cs
+++ b/src/port/McpCliCommand.cs
@@ -7,10 +7,10 @@ namespace port;
 
 public class McpCliCommand : AsyncCommand<McpSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, McpSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, McpSettings settings, CancellationToken cancellationToken)
     {
         AnsiConsole.Console = SilentConsole.Create();
-        await McpHost.RunAsync();
+        await McpHost.RunAsync(cancellationToken);
         return 0;
     }
 }


### PR DESCRIPTION
Bumps Spectre.Console and Spectre.Console.Cli 0.51.1 → 0.53.1.

0.53 adds a `CancellationToken` parameter to the `Command`/`AsyncCommand` `Execute(Async)` abstract methods, so every command override is updated and the token is threaded end-to-end (commands → orchestrators, list refresh, resolution queries via `ToListAsync(ct)`, and `McpHost.RunAsync`).

Builds clean locally (0 warnings, 0 errors).

Supersedes #173 — a pre-restructure Dependabot relic that shared only an ancient ancestor with `master` and couldn't be rebased.