### PR TITLE
Bump DotNext.Threading from 5.24.0 to 6.4.1 (major)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
-    <PackageVersion Include="DotNext.Threading" Version="5.24.0" />
+    <PackageVersion Include="DotNext.Threading" Version="6.4.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />


### PR DESCRIPTION
Major upgrade of DotNext.Threading 5.24.0 → **6.4.1** (5.x → 6.x).

The only usage in the codebase is the `AsyncLazy<T>` cache in `GetContainersQuery` (`new AsyncLazy<T>(async token => …)` + `.WithCancellation(token)`); that API is unchanged in 6.x, so **no code migration was required**. Builds clean (0 warnings / 0 errors).

⚠️ Major bump — since port has no test suite, worth a quick manual smoke-run (`port list`/`run`) before/after merge to confirm the container-list cache behaves the same at runtime.